### PR TITLE
Feature/dialogs qpointer autodelete

### DIFF
--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -12,7 +12,7 @@
 #include "jobs/jobeditor/jobpatheditor.h"
 #include <QDockWidget>
 
-#include <QPointer>
+#include "utils/owningqpointer.h"
 #include <QMessageBox>
 #include <QPushButton>
 #include <QLabel>
@@ -54,8 +54,6 @@
 #include <QTimer> //HACK: TODO remove
 
 #include "app/scopedebug.h"
-
-#include <QPointer>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -236,8 +234,7 @@ void MainWindow::setup_actions()
 
 void MainWindow::about()
 {
-    QPointer<QMessageBox> msgBox = new QMessageBox(this);
-    msgBox->setAttribute(Qt::WA_DeleteOnClose);
+    OwningQPointer<QMessageBox> msgBox = new QMessageBox(this);
     msgBox->setIcon(QMessageBox::Information);
     msgBox->setWindowTitle(tr("About %1").arg(qApp->applicationDisplayName()));
 
@@ -257,7 +254,6 @@ void MainWindow::about()
     msgBox->setText(translatedText);
     msgBox->setStandardButtons(QMessageBox::Ok);
     msgBox->exec();
-    delete msgBox;
 }
 
 void MainWindow::onOpen()
@@ -377,7 +373,7 @@ void MainWindow::loadFile(const QString& fileName)
         //Probably the application crashed before finishing RS importation
         //Give user choice to resume it or discard
 
-        QPointer<QMessageBox> msgBox = new QMessageBox(
+        OwningQPointer<QMessageBox> msgBox = new QMessageBox(
             QMessageBox::Warning,
             tr("RS Import"),
             tr("There is some rollingstock import data left in this file. "
@@ -391,18 +387,15 @@ void MainWindow::loadFile(const QString& fileName)
         msgBox->setTextFormat(Qt::RichText);
 
         msgBox->exec();
+        if(!msgBox)
+            return;
 
-        if(msgBox)
+        if(msgBox->clickedButton() == resumeBut)
         {
-            if(msgBox->clickedButton() == resumeBut)
-            {
-                Session->getViewManager()->resumeRSImportation();
-            }else{
-                Session->clearImportRSTables();
-            }
+            Session->getViewManager()->resumeRSImportation();
+        }else{
+            Session->clearImportRSTables();
         }
-
-        delete msgBox;
     }
 }
 
@@ -721,18 +714,16 @@ void MainWindow::onCloseSession()
 
 void MainWindow::onProperties()
 {
-    QPointer<PropertiesDialog> dlg = new PropertiesDialog(this);
+    OwningQPointer<PropertiesDialog> dlg = new PropertiesDialog(this);
     dlg->exec();
-    delete dlg;
 }
 
 void MainWindow::onMeetingInformation()
 {
-    QPointer<MeetingInformationDialog> dlg = new MeetingInformationDialog(this);
+    OwningQPointer<MeetingInformationDialog> dlg = new MeetingInformationDialog(this);
     int ret = dlg->exec();
     if(dlg && ret == QDialog::Accepted)
         dlg->saveData();
-    delete dlg;
 }
 
 bool MainWindow::closeSession()
@@ -798,26 +789,23 @@ void MainWindow::onRemoveJob()
 
 void MainWindow::onPrint()
 {
-    QPointer<PrintWizard> wizard = new PrintWizard(Session->m_Db, this);
+    OwningQPointer<PrintWizard> wizard = new PrintWizard(Session->m_Db, this);
     wizard->setOutputType(Print::Native);
     wizard->exec();
-    delete wizard;
 }
 
 void MainWindow::onPrintPDF()
 {
-    QPointer<PrintWizard> wizard = new PrintWizard(Session->m_Db, this);
+    OwningQPointer<PrintWizard> wizard = new PrintWizard(Session->m_Db, this);
     wizard->setOutputType(Print::Pdf);
     wizard->exec();
-    delete wizard;
 }
 
 void MainWindow::onExportSvg()
 {
-    QPointer<PrintWizard> wizard = new PrintWizard(Session->m_Db, this);
+    OwningQPointer<PrintWizard> wizard = new PrintWizard(Session->m_Db, this);
     wizard->setOutputType(Print::Svg);
     wizard->exec();
-    delete wizard;
 }
 
 #ifdef ENABLE_USER_QUERY
@@ -833,10 +821,9 @@ void MainWindow::onExecQuery()
 void MainWindow::onOpenSettings()
 {
     DEBUG_ENTRY;
-    QPointer<SettingsDialog> dlg = new SettingsDialog(this);
+    OwningQPointer<SettingsDialog> dlg = new SettingsDialog(this);
     dlg->loadSettings();
     dlg->exec();
-    delete dlg;
 }
 
 void MainWindow::checkLineNumber()

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -280,21 +280,21 @@ void MainWindow::onOpen()
     }
 #endif
 
-    QFileDialog dlg(this, tr("Open Session"));
-    dlg.setFileMode(QFileDialog::ExistingFile);
-    dlg.setAcceptMode(QFileDialog::AcceptOpen);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Open Session"));
+    dlg->setFileMode(QFileDialog::ExistingFile);
+    dlg->setAcceptMode(QFileDialog::AcceptOpen);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::tttFormat);
     filters << FileFormats::tr(FileFormats::sqliteFormat);
     filters << FileFormats::tr(FileFormats::allFiles);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;
@@ -496,21 +496,21 @@ void MainWindow::onNew()
     }
 #endif
 
-    QFileDialog dlg(this, tr("Create new Session"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Create new Session"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::tttFormat);
     filters << FileFormats::tr(FileFormats::sqliteFormat);
     filters << FileFormats::tr(FileFormats::allFiles);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;
@@ -560,21 +560,21 @@ void MainWindow::onSaveCopyAs()
     if(!Session->getViewManager()->closeEditors())
         return;
 
-    QFileDialog dlg(this, tr("Save Session Copy"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Save Session Copy"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::tttFormat);
     filters << FileFormats::tr(FileFormats::sqliteFormat);
     filters << FileFormats::tr(FileFormats::allFiles);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;

--- a/src/db_metadata/meetinginformationdialog.cpp
+++ b/src/db_metadata/meetinginformationdialog.cpp
@@ -14,6 +14,7 @@
 #include <QStandardPaths>
 
 #include "utils/imageviewer.h"
+#include "utils/owningqpointer.h"
 
 #include <QDebug>
 
@@ -181,7 +182,7 @@ void MeetingInformationDialog::saveData()
 
 void MeetingInformationDialog::showImage()
 {
-    QPointer<ImageViewer> dlg = new ImageViewer(this);
+    OwningQPointer<ImageViewer> dlg = new ImageViewer(this);
 
     if(img.isNull() && !needsToSaveImg)
     {
@@ -209,7 +210,6 @@ void MeetingInformationDialog::showImage()
     dlg->setImage(img);
 
     dlg->exec();
-    delete dlg;
 
     if(!needsToSaveImg)
         img = QImage(); //Cleanup to free memory

--- a/src/db_metadata/meetinginformationdialog.cpp
+++ b/src/db_metadata/meetinginformationdialog.cpp
@@ -217,10 +217,10 @@ void MeetingInformationDialog::showImage()
 
 void MeetingInformationDialog::importImage()
 {
-    QFileDialog dlg(this, tr("Import image"));
-    dlg.setFileMode(QFileDialog::ExistingFile);
-    dlg.setAcceptMode(QFileDialog::AcceptOpen);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Import image"));
+    dlg->setFileMode(QFileDialog::ExistingFile);
+    dlg->setAcceptMode(QFileDialog::AcceptOpen);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::PicturesLocation));
 
     QList<QByteArray> mimes = QImageReader::supportedMimeTypes();
     QStringList filters;
@@ -230,12 +230,12 @@ void MeetingInformationDialog::importImage()
 
     filters << "application/octet-stream"; // will show "All files (*)"
 
-    dlg.setMimeTypeFilters(filters);
+    dlg->setMimeTypeFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
     if(fileName.isEmpty())
         return;
 

--- a/src/jobs/jobeditor/editstopdialog.cpp
+++ b/src/jobs/jobeditor/editstopdialog.cpp
@@ -13,7 +13,7 @@
 #include "utils/jobcategorystrings.h"
 
 #include <QMessageBox>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include <QtMath>
 
@@ -437,12 +437,11 @@ void EditStopDialog::editCoupled()
     coupledModel->clearCache();
     trainAssetModelAfter->clearCache();
 
-    QPointer<RSCoupleDialog> dlg = new RSCoupleDialog(couplingMgr, RsOp::Coupled, this);
+    OwningQPointer<RSCoupleDialog> dlg = new RSCoupleDialog(couplingMgr, RsOp::Coupled, this);
     dlg->setWindowTitle(tr("Couple"));
     dlg->loadProxyModels(Session->m_Db, m_jobId, m_stopId, m_stationId, ui->arrivalTimeEdit->time());
 
     dlg->exec();
-    delete dlg;
 
     coupledModel->refreshData(true);
     trainAssetModelAfter->refreshData(true);
@@ -455,12 +454,11 @@ void EditStopDialog::editUncoupled()
     uncoupledModel->clearCache();
     trainAssetModelAfter->clearCache();
 
-    QPointer<RSCoupleDialog> dlg = new RSCoupleDialog(couplingMgr, RsOp::Uncoupled, this);
+    OwningQPointer<RSCoupleDialog> dlg = new RSCoupleDialog(couplingMgr, RsOp::Uncoupled, this);
     dlg->setWindowTitle(tr("Uncouple"));
     dlg->loadProxyModels(Session->m_Db, m_jobId, m_stopId, m_stationId, originalArrival);
 
     dlg->exec();
-    delete dlg;
 
     uncoupledModel->refreshData(true);
     trainAssetModelAfter->refreshData(true);

--- a/src/jobs/jobeditor/jobpatheditor.cpp
+++ b/src/jobs/jobeditor/jobpatheditor.cpp
@@ -660,20 +660,20 @@ void JobPathEditor::setReadOnly(bool readOnly)
 
 void JobPathEditor::onSaveSheet()
 {
-    QFileDialog dlg(this, tr("Save Job Sheet"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
-    dlg.selectFile(tr("job%1_sheet.odt").arg(stopModel->getJobId()));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Save Job Sheet"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    dlg->selectFile(tr("job%1_sheet.odt").arg(stopModel->getJobId()));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::odtFormat);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;

--- a/src/jobs/jobeditor/jobpatheditor.cpp
+++ b/src/jobs/jobeditor/jobpatheditor.cpp
@@ -10,7 +10,7 @@
 #include <QStandardPaths>
 
 #include <QMessageBox>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include <QCloseEvent>
 
@@ -269,11 +269,10 @@ void JobPathEditor::showContextMenu(const QPoint& pos)
 
     if(act == editStopAct)
     {
-        QPointer<EditStopDialog> dlg = new EditStopDialog(this);
+        OwningQPointer<EditStopDialog> dlg = new EditStopDialog(this);
         dlg->setReadOnly(m_readOnly);
         dlg->setStop(stopModel, index);
         dlg->exec();
-        delete dlg;
         return;
     }
 
@@ -420,10 +419,9 @@ bool JobPathEditor::saveChanges()
                        times.first, times.second);
         if(model.hasConcurrentJobs())
         {
-            QPointer<ShiftBusyDlg> dlg = new ShiftBusyDlg(this);
+            OwningQPointer<ShiftBusyDlg> dlg = new ShiftBusyDlg(this);
             dlg->setModel(&model);
             dlg->exec();
-            delete dlg;
 
             stopModel->setNewShiftId(stopModel->getJobShiftId());
 
@@ -602,10 +600,9 @@ void JobPathEditor::onJobShiftChanged(db_id shiftId)
                        times.first, times.second);
         if(model.hasConcurrentJobs())
         {
-            QPointer<ShiftBusyDlg> dlg = new ShiftBusyDlg(this);
+            OwningQPointer<ShiftBusyDlg> dlg = new ShiftBusyDlg(this);
             dlg->setModel(&model);
             dlg->exec();
-            delete dlg;
 
             stopModel->setNewShiftId(0);
 

--- a/src/printing/printoptionspage.cpp
+++ b/src/printing/printoptionspage.cpp
@@ -13,9 +13,10 @@
 #include <QGridLayout>
 
 #include "utils/file_format_names.h"
+#include "utils/owningqpointer.h"
+
 #include <QFileDialog>
 #include <QPrintDialog>
-#include <QPointer>
 
 #include <QFileInfo>
 #include <QStandardPaths>
@@ -266,7 +267,7 @@ void PrintOptionsPage::updateDifferentFiles()
 
 void PrintOptionsPage::onOpenPrintDlg()
 {
-    QPointer<QPrintDialog> dlg = new QPrintDialog(mWizard->getPrinter(), this);
+    OwningQPointer<QPrintDialog> dlg = new QPrintDialog(mWizard->getPrinter(), this);
     dlg->exec();
     delete dlg;
 }

--- a/src/printing/printwizard.cpp
+++ b/src/printing/printwizard.cpp
@@ -11,7 +11,7 @@
 
 #include <QMessageBox>
 #include <QPushButton>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include <QPrinter>
 
@@ -172,7 +172,7 @@ void PrintWizard::done(int result)
     {
         if(!isStoppingTask)
         {
-            QPointer<QMessageBox> msgBox = new QMessageBox(this);
+            OwningQPointer<QMessageBox> msgBox = new QMessageBox(this);
             msgBox->setIcon(QMessageBox::Question);
             msgBox->setWindowTitle(tr("Abort Printing?"));
             msgBox->setText(tr("Do you want to cancel printing?\n"
@@ -183,7 +183,6 @@ void PrintWizard::done(int result)
             msgBox->setEscapeButton(noBut); //Do not Abort if dialog is closed by Esc or X window button
             msgBox->exec();
             bool abortClicked = msgBox && msgBox->clickedButton() == abortBut;
-            delete msgBox;
             if(!abortClicked)
                 return;
 
@@ -234,7 +233,7 @@ void PrintWizard::abortPrintTask()
 
 void PrintWizard::handleProgressError(const QString &errMsg)
 {
-    QPointer<QMessageBox> msgBox = new QMessageBox(this);
+    OwningQPointer<QMessageBox> msgBox = new QMessageBox(this);
     msgBox->setIcon(QMessageBox::Warning);
     auto tryAgainBut = msgBox->addButton(tr("Try again"), QMessageBox::YesRole);
     msgBox->addButton(QMessageBox::Abort);
@@ -243,15 +242,12 @@ void PrintWizard::handleProgressError(const QString &errMsg)
     msgBox->setWindowTitle(tr("Print Error"));
 
     msgBox->exec();
+    if(!msgBox)
+        return;
 
-    if(msgBox)
+    if(msgBox->clickedButton() == tryAgainBut)
     {
-        if(msgBox->clickedButton() == tryAgainBut)
-        {
-            //Go back to options page
-            back();
-        }
+        //Go back to options page
+        back();
     }
-
-    delete msgBox;
 }

--- a/src/printing/selectionpage.cpp
+++ b/src/printing/selectionpage.cpp
@@ -11,7 +11,7 @@
 
 #include <QDialog>
 #include <QDialogButtonBox>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include "graph/view/linegraphselectionwidget.h"
 
@@ -115,7 +115,7 @@ void PrintSelectionPage::onAddItem()
 
     const LineGraphType requestedType = model->getSelectedType();
 
-    QPointer<QDialog> dlg = new QDialog(this);
+    OwningQPointer<QDialog> dlg = new QDialog(this);
     QVBoxLayout *lay = new QVBoxLayout(dlg);
 
     LineGraphSelectionWidget *selectionWidget = new LineGraphSelectionWidget;
@@ -142,17 +142,15 @@ void PrintSelectionPage::onAddItem()
     connect(selectionWidget, &LineGraphSelectionWidget::graphChanged, this, updateDlg);
     updateDlg();
 
-    if(dlg->exec() == QDialog::Accepted && dlg)
-    {
-        SceneSelectionModel::Entry entry;
-        entry.objectId = selectionWidget->getObjectId();
-        entry.name = selectionWidget->getObjectName();
-        entry.type = selectionWidget->getGraphType();
+    if(dlg->exec() != QDialog::Accepted)
+        return;
 
-        model->addEntry(entry);
-    }
+    SceneSelectionModel::Entry entry;
+    entry.objectId = selectionWidget->getObjectId();
+    entry.name = selectionWidget->getObjectName();
+    entry.type = selectionWidget->getGraphType();
 
-    delete dlg;
+    model->addEntry(entry);
 }
 
 void PrintSelectionPage::onRemoveItem()

--- a/src/rollingstock/importer/pages/choosefilepage.cpp
+++ b/src/rollingstock/importer/pages/choosefilepage.cpp
@@ -6,6 +6,7 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
+#include "utils/owningqpointer.h"
 
 #include <QDir>
 
@@ -94,14 +95,14 @@ void ChooseFilePage::onChoose()
     }
     filters << FileFormats::tr(FileFormats::allFiles);
 
-    QFileDialog dlg(this, title, pathEdit->text());
-    dlg.setFileMode(QFileDialog::ExistingFile);
-    dlg.setAcceptMode(QFileDialog::AcceptOpen);
-    dlg.setNameFilters(filters);
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, title, pathEdit->text());
+    dlg->setFileMode(QFileDialog::ExistingFile);
+    dlg->setAcceptMode(QFileDialog::AcceptOpen);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
     pathEdit->setText(QDir::toNativeSeparators(fileName));
 }

--- a/src/rollingstock/importer/pages/fixduplicatesdlg.cpp
+++ b/src/rollingstock/importer/pages/fixduplicatesdlg.cpp
@@ -8,7 +8,7 @@
 
 #include <QProgressDialog>
 #include <QMessageBox>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include "../intefaces/iduplicatesitemmodel.h"
 
@@ -106,7 +106,7 @@ void FixDuplicatesDlg::done(int res)
         int count = model->getItemCount();
         if(count)
         {
-            QPointer<QMessageBox> msgBox = new QMessageBox(this);
+            OwningQPointer<QMessageBox> msgBox = new QMessageBox(this);
             msgBox->setIcon(QMessageBox::Warning);
             msgBox->setWindowTitle(RsImportStrings::tr("Not yet!"));
             msgBox->setText(RsImportStrings::tr("There are still %1 items to be fixed").arg(count));
@@ -119,7 +119,6 @@ void FixDuplicatesDlg::done(int res)
             msgBox->exec();
 
             const bool goBack = msgBox && msgBox->clickedButton() == backToPrevPage && backToPrevPage;
-            delete msgBox;
 
             if(goBack)
             {
@@ -190,7 +189,7 @@ int FixDuplicatesDlg::blockingReloadCount(int mode)
 int FixDuplicatesDlg::warnCancel(QWidget *w)
 {
     //Warn user
-    QPointer<QMessageBox> msgBox = new QMessageBox(w);
+    OwningQPointer<QMessageBox> msgBox = new QMessageBox(w);
     msgBox->setIcon(QMessageBox::Warning);
     msgBox->setWindowTitle(RsImportStrings::tr("Aborting RS Import"));
     msgBox->setText(RsImportStrings::tr("If you don't fix duplicated items you cannot proceed.\n"
@@ -220,8 +219,6 @@ int FixDuplicatesDlg::warnCancel(QWidget *w)
     {
         ret = FixDuplicatesDlg::GoBackToPrevPage;
     }
-
-    delete msgBox;
 
     return ret;
 }

--- a/src/rollingstock/importer/pages/itemselectionpage.cpp
+++ b/src/rollingstock/importer/pages/itemselectionpage.cpp
@@ -7,7 +7,7 @@
 #include <QVBoxLayout>
 #include <QMessageBox>
 
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include "../rsimportwizard.h"
 #include "../intefaces/irsimportmodel.h"
@@ -114,7 +114,7 @@ void ItemSelectionPage::initializePage()
     dupModel.reset(IDuplicatesItemModel::createModel(m_mode, model->getDb(), model, this));
 
     bool canGoBack = mWizard->currentId() != RSImportWizard::SelectOwnersIdx;
-    QPointer<FixDuplicatesDlg> dlg = new FixDuplicatesDlg(dupModel.get(), canGoBack, this);
+    OwningQPointer<FixDuplicatesDlg> dlg = new FixDuplicatesDlg(dupModel.get(), canGoBack, this);
     if(m_mode == ModelModes::Rollingstock && editorFactory)
     {
         QStyledItemDelegate *delegate = new QStyledItemDelegate(this);
@@ -133,14 +133,12 @@ void ItemSelectionPage::initializePage()
          * (that is 1 before current that is already the old page)
          * Solution: call it after 'initializePage()' has finished by posting an event
          */
-        delete dlg;
         mWizard->goToPrevPageQueued();
         return;
     }
     else if(res != QDialog::Accepted)
     {
         //Prevent showing another message box asking user if he is sure about quitting
-        delete dlg;
         mWizard->done(RSImportWizard::RejectWithoutAsking);
         return;
     }
@@ -149,7 +147,6 @@ void ItemSelectionPage::initializePage()
     {
         //We have duplicates, run dialog
         res = dlg->exec();
-        delete dlg;
         if(res == FixDuplicatesDlg::GoBackToPrevPage && canGoBack)
         {
             /* HACK: see above */
@@ -163,8 +160,6 @@ void ItemSelectionPage::initializePage()
             return;
         }
     }
-
-    delete dlg;
 
     //Duplicates are now fixed, refresh main model
     model->refreshData();

--- a/src/rollingstock/importer/rsimportwizard.cpp
+++ b/src/rollingstock/importer/rsimportwizard.cpp
@@ -31,7 +31,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 RSImportWizard::RSImportWizard(bool resume, QWidget *parent) :
     QWizard (parent),
@@ -95,7 +95,7 @@ void RSImportWizard::done(int result)
         {
             if(result == QDialog::Rejected) //RejectWithoutAsking skips this
             {
-                QPointer<QMessageBox> msgBox = new QMessageBox(this);
+                OwningQPointer<QMessageBox> msgBox = new QMessageBox(this);
                 msgBox->setIcon(QMessageBox::Question);
                 msgBox->setWindowTitle(RsImportStrings::tr("Abort import?"));
                 msgBox->setText(RsImportStrings::tr("Do you want to import process? No data will be imported"));
@@ -105,7 +105,6 @@ void RSImportWizard::done(int result)
                 msgBox->setEscapeButton(noBut); //Do not Abort if dialog is closed by Esc or X window button
                 msgBox->exec();
                 bool abortClicked = msgBox && msgBox->clickedButton() == abortBut;
-                delete msgBox;
                 if(!abortClicked)
                     return;
             }

--- a/src/shifts/shiftgraph/jobchangeshiftdlg.cpp
+++ b/src/shifts/shiftgraph/jobchangeshiftdlg.cpp
@@ -5,7 +5,7 @@
 #include <QComboBox>
 #include <QMessageBox>
 #include <QVBoxLayout>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include "utils/sqldelegate/customcompletionlineedit.h"
 #include "shifts/shiftcombomodel.h"
@@ -72,10 +72,9 @@ void JobChangeShiftDlg::done(int ret)
             model.loadData(shiftId, mJobId, start, end);
             if(model.hasConcurrentJobs())
             {
-                QPointer<ShiftBusyDlg> dlg = new ShiftBusyDlg(this);
+                OwningQPointer<ShiftBusyDlg> dlg = new ShiftBusyDlg(this);
                 dlg->setModel(&model);
                 dlg->exec();
-                delete dlg;
                 return;
             }
 

--- a/src/shifts/shiftgraph/shiftgrapheditor.cpp
+++ b/src/shifts/shiftgraph/shiftgrapheditor.cpp
@@ -26,8 +26,7 @@
 #include <QPainter>
 
 #include <QPrintDialog>
-#include <QPointer>
-
+#include "utils/owningqpointer.h"
 #include "info.h"
 
 ShiftGraphEditor::ShiftGraphEditor(QWidget *parent) :
@@ -103,13 +102,12 @@ void ShiftGraphEditor::onPrintGraph()
 {
     QPrinter printer;
 
-    QPointer<QPrintDialog> dlg = new QPrintDialog(&printer, this);
-    if(dlg->exec() == QDialog::Accepted && dlg)
-    {
-        print(&printer);
-    }
+    OwningQPointer<QPrintDialog> dlg = new QPrintDialog(&printer, this);
 
-    delete dlg;
+    if(dlg->exec() != QDialog::Accepted)
+        return;
+
+    print(&printer);
 }
 
 void ShiftGraphEditor::exportSVG(const QString& fileName)
@@ -163,7 +161,7 @@ void ShiftGraphEditor::refreshView()
 
 void ShiftGraphEditor::onShowOptions()
 {
-    QPointer<GraphOptions> dlg = new GraphOptions(this);
+    OwningQPointer<GraphOptions> dlg = new GraphOptions(this);
     dlg->setHideSameStations(graph->getHideSameStations());
 
     int ret = dlg->exec();
@@ -171,14 +169,11 @@ void ShiftGraphEditor::onShowOptions()
     {
         graph->setHideSameStations(dlg->hideSameStation());
     }
-
-    delete dlg;
 }
 
 void ShiftGraphEditor::showShiftMenuForJob(db_id jobId)
 {
-    QPointer<JobChangeShiftDlg> dlg = new JobChangeShiftDlg(Session->m_Db, this);
+    OwningQPointer<JobChangeShiftDlg> dlg = new JobChangeShiftDlg(Session->m_Db, this);
     dlg->setJob(jobId);
     dlg->exec();
-    delete dlg;
 }

--- a/src/shifts/shiftgraph/shiftgrapheditor.cpp
+++ b/src/shifts/shiftgraph/shiftgrapheditor.cpp
@@ -62,33 +62,25 @@ ShiftGraphEditor::~ShiftGraphEditor()
 
 void ShiftGraphEditor::onSaveGraph()
 {
-    QFileDialog dlg(this, tr("Save Shift Graph"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Save Shift Graph"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::svgFile);
     filters << FileFormats::tr(FileFormats::pdfFile);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;
 
-    if(fileName.endsWith(QStringLiteral(".pdf")))
-    {
-        exportPDF(fileName);
-    }
-    else if(fileName.endsWith(QStringLiteral(".svg")))
-    {
-        exportSVG(fileName);
-    }
-    else if(dlg.selectedNameFilter().contains("pdf")) //TODO: needed?
+    if(fileName.endsWith(QStringLiteral(".pdf")) || dlg->selectedNameFilter().contains("pdf"))
     {
         exportPDF(fileName);
     }

--- a/src/shifts/shiftmanager.cpp
+++ b/src/shifts/shiftmanager.cpp
@@ -14,6 +14,7 @@
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QMessageBox>
+#include "utils/owningqpointer.h"
 
 #include <QToolBar>
 #include <QActionGroup>
@@ -154,21 +155,20 @@ void ShiftManager::onSaveSheet()
     QString shiftName = model->shiftNameAtRow(idx.row());
     qDebug() << "Printing Shift:" << shiftId;
 
-    QFileDialog dlg(this, tr("Save Shift Sheet"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
-    dlg.selectFile(tr("shift_%1.odt").arg(shiftName));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Save Shift Sheet"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    dlg->selectFile(tr("shift_%1.odt").arg(shiftName));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::odtFormat);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
-
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
     if(fileName.isEmpty())
         return;
 

--- a/src/stations/manager/lines/dialogs/editlinedlg.cpp
+++ b/src/stations/manager/lines/dialogs/editlinedlg.cpp
@@ -16,7 +16,7 @@
 #include "stations/manager/lines/model/linesegmentsmodel.h"
 #include "stations/manager/lines/dialogs/choosesegmentdlg.h"
 
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 
 EditLineDlg::EditLineDlg(sqlite3pp::database &db, QWidget *parent) :
@@ -141,17 +141,11 @@ void EditLineDlg::addStation()
     db_id lastStationId = model->getLastStation();
     db_id lastSegmentId = model->getLastRailwaySegment();
 
-    QPointer<ChooseSegmentDlg> dlg(new ChooseSegmentDlg(mDb, this));
+    OwningQPointer<ChooseSegmentDlg> dlg(new ChooseSegmentDlg(mDb, this));
     dlg->setFilter(lastStationId, ChooseSegmentDlg::DoNotLock, lastSegmentId);
     int ret = dlg->exec();
-    if(!dlg)
+    if(ret != QDialog::Accepted || !dlg)
         return;
-
-    if(ret != QDialog::Accepted)
-    {
-        delete dlg;
-        return;
-    }
 
     db_id segmentId = 0;
     QString segmentName;
@@ -161,8 +155,6 @@ void EditLineDlg::addStation()
     {
         model->addStation(segmentId, isReversed);
     }
-
-    delete dlg;
 }
 
 void EditLineDlg::removeAfterCurrentPos()

--- a/src/stations/manager/segments/dialogs/editrailwaysegmentdlg.cpp
+++ b/src/stations/manager/segments/dialogs/editrailwaysegmentdlg.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include "utils/sqldelegate/customcompletionlineedit.h"
 
+#include "utils/owningqpointer.h"
+
 #include "stations/match_models/stationsmatchmodel.h"
 #include "stations/match_models/stationgatesmatchmodel.h"
 
@@ -20,7 +22,6 @@
 #include "stations/manager/segments/model/railwaysegmentconnectionsmodel.h"
 
 #include "stations/manager/segments/dialogs/editrailwayconnectiondlg.h"
-#include <QPointer>
 
 EditRailwaySegmentDlg::EditRailwaySegmentDlg(sqlite3pp::database &db, QWidget *parent) :
     QDialog(parent),
@@ -315,8 +316,6 @@ void EditRailwaySegmentDlg::updateTrackConnectionModel()
 
 void EditRailwaySegmentDlg::editSegmentTrackConnections()
 {
-    QPointer<EditRailwayConnectionDlg> dlg(new EditRailwayConnectionDlg(connModel, this));
+    OwningQPointer<EditRailwayConnectionDlg> dlg(new EditRailwayConnectionDlg(connModel, this));
     dlg->exec();
-    if(dlg)
-        delete dlg;
 }

--- a/src/stations/manager/stationjobview.cpp
+++ b/src/stations/manager/stationjobview.cpp
@@ -16,6 +16,7 @@
 
 #include <QFileDialog>
 #include <QStandardPaths>
+#include "utils/owningqpointer.h"
 
 #include "odt_export/stationsheetexport.h"
 
@@ -112,20 +113,20 @@ void StationJobView::onSaveSheet()
 {
     DEBUG_ENTRY;
 
-    QFileDialog dlg(this, tr("Save Station Sheet"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
-    dlg.selectFile(tr("%1_station.odt").arg(windowTitle()));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Save Station Sheet"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    dlg->selectFile(tr("%1_station.odt").arg(windowTitle()));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::odtFormat);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;

--- a/src/stations/manager/stations/dialogs/stationeditdialog.cpp
+++ b/src/stations/manager/stations/dialogs/stationeditdialog.cpp
@@ -32,7 +32,7 @@
 #include <QFileDialog>
 #include "utils/file_format_names.h"
 
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 void setupView(QTableView *view, IPagedItemModel *model)
 {
@@ -332,7 +332,7 @@ void StationEditDialog::onGatesChanged()
 
 void StationEditDialog::addGate()
 {
-    QPointer<QInputDialog> dlg = new QInputDialog(this);
+    OwningQPointer<QInputDialog> dlg = new QInputDialog(this);
     dlg->setWindowTitle(tr("Add Gate"));
     dlg->setLabelText(tr("Please choose a letter for the new station gate."));
     dlg->setTextValue(QString());
@@ -358,8 +358,6 @@ void StationEditDialog::addGate()
         }
     }
     while (true);
-
-    delete dlg;
 }
 
 void StationEditDialog::removeSelectedGate()
@@ -388,7 +386,7 @@ void StationEditDialog::onTracksChanged()
 
 void StationEditDialog::addTrack()
 {
-    QPointer<QInputDialog> dlg = new QInputDialog(this);
+    OwningQPointer<QInputDialog> dlg = new QInputDialog(this);
     dlg->setWindowTitle(tr("Add Track"));
     dlg->setLabelText(tr("Please choose a name for the new station track."));
     dlg->setTextValue(QString());
@@ -414,8 +412,6 @@ void StationEditDialog::addTrack()
         }
     }
     while (true);
-
-    delete dlg;
 }
 
 void StationEditDialog::removeSelectedTrack()
@@ -483,9 +479,9 @@ void StationEditDialog::addTrackConnInternal(int mode)
     QScopedPointer<ISqlFKMatchModel> tracks(trackFactory->createModel());
     QScopedPointer<ISqlFKMatchModel> gates(gatesFactory->createModel());
 
-    QPointer<NewTrackConnDlg> dlg = new NewTrackConnDlg(tracks.get(),
-                                                        static_cast<StationGatesMatchModel *>(gates.get()),
-                                                        this);
+    OwningQPointer<NewTrackConnDlg> dlg = new NewTrackConnDlg(tracks.get(),
+                                                              static_cast<StationGatesMatchModel *>(gates.get()),
+                                                              this);
     dlg->setMode(dlgMode);
 
     do{
@@ -521,8 +517,6 @@ void StationEditDialog::addTrackConnInternal(int mode)
         }
     }
     while (true);
-
-    delete dlg;
 }
 
 void StationEditDialog::updateSVGButtons(bool hasImage)
@@ -546,14 +540,10 @@ void StationEditDialog::removeSelectedTrackConn()
 
 void StationEditDialog::addGateConnection()
 {
-    QPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(mDb, this));
+    OwningQPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(mDb, this));
     dlg->setSegment(0, getStation(), EditRailwaySegmentDlg::DoNotLock);
     int ret = dlg->exec();
-    if(!dlg)
-        return;
-    delete dlg;
-
-    if(ret != QDialog::Accepted)
+    if(ret != QDialog::Accepted || !dlg)
         return;
 
     gateConnModel->refreshData(); //Recalc row count
@@ -568,14 +558,10 @@ void StationEditDialog::editGateConnection()
     if(!segId)
         return;
 
-    QPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(mDb, this));
+    OwningQPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(mDb, this));
     dlg->setSegment(segId, getStation(), EditRailwaySegmentDlg::LockToCurrentValue);
     int ret = dlg->exec();
-    if(!dlg)
-        return;
-    delete dlg;
-
-    if(ret != QDialog::Accepted)
+    if(ret != QDialog::Accepted || !dlg)
         return;
 
     gateConnModel->refreshData(true); //Refresh fields

--- a/src/stations/manager/stations/dialogs/stationeditdialog.cpp
+++ b/src/stations/manager/stations/dialogs/stationeditdialog.cpp
@@ -590,20 +590,20 @@ void StationEditDialog::removeSelectedGateConnection()
 
 void StationEditDialog::addSVGImage()
 {
-    QFileDialog dlg(this, tr("Open SVG Image"));
-    dlg.setFileMode(QFileDialog::ExistingFile);
-    dlg.setAcceptMode(QFileDialog::AcceptOpen);
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Open SVG Image"));
+    dlg->setFileMode(QFileDialog::ExistingFile);
+    dlg->setAcceptMode(QFileDialog::AcceptOpen);
     //dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::svgFile);
     filters << FileFormats::tr(FileFormats::allFiles);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
 
     if(fileName.isEmpty())
         return;
@@ -644,21 +644,20 @@ void StationEditDialog::removeSVGImage()
 
 void StationEditDialog::saveSVGToFile()
 {
-    QFileDialog dlg(this, tr("Save SVG Copy"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Save SVG Copy"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
     //dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::svgFile);
     filters << FileFormats::tr(FileFormats::allFiles);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
-
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
     if(fileName.isEmpty())
         return;
 

--- a/src/stations/manager/stations/dialogs/stationsvgplandlg.cpp
+++ b/src/stations/manager/stations/dialogs/stationsvgplandlg.cpp
@@ -12,7 +12,7 @@
 
 #include <QMessageBox>
 #include <QPushButton>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 #include <ssplib/svgstationplanlib.h>
 
@@ -228,7 +228,7 @@ void StationSVGPlanDlg::onLabelClicked(qint64 gateId, QChar letter, const QStrin
                    << "NOT OF THIS STATION" << stationId;
     }
 
-    QPointer<QMessageBox> msgBox = new QMessageBox(this);
+    OwningQPointer<QMessageBox> msgBox = new QMessageBox(this);
     msgBox->setIcon(QMessageBox::Information);
     msgBox->setWindowTitle(tr("Gate %1").arg(letter));
 
@@ -265,8 +265,6 @@ void StationSVGPlanDlg::onLabelClicked(qint64 gateId, QChar letter, const QStrin
     {
         Session->getViewManager()->requestStSVGPlan(info.to.stationId);
     }
-
-    delete msgBox;
 }
 
 void StationSVGPlanDlg::showEvent(QShowEvent *)

--- a/src/stations/manager/stationsmanager.cpp
+++ b/src/stations/manager/stationsmanager.cpp
@@ -35,7 +35,7 @@
 #include "stations/manager/lines/dialogs/editlinedlg.h"
 
 #include <QInputDialog>
-#include <QPointer>
+#include "utils/owningqpointer.h"
 
 StationsManager::StationsManager(QWidget *parent) :
     QWidget(parent),
@@ -302,7 +302,7 @@ void StationsManager::onNewStation()
 {
     DEBUG_ENTRY;
 
-    QPointer<QInputDialog> dlg = new QInputDialog(this);
+    OwningQPointer<QInputDialog> dlg = new QInputDialog(this);
     dlg->setWindowTitle(tr("Add Station"));
     dlg->setLabelText(tr("Please choose a name for the new station."));
     dlg->setTextValue(QString());
@@ -328,8 +328,6 @@ void StationsManager::onNewStation()
     }
     while (true);
 
-    delete dlg;
-
     //TODO
     //    QModelIndex idx = stationsModel->index(row, 0);
     //    stationView->setCurrentIndex(idx);
@@ -353,15 +351,12 @@ void StationsManager::onEditStation()
     if(!stId)
         return;
 
-    QPointer<StationEditDialog> dlg(new StationEditDialog(Session->m_Db, this));
+    OwningQPointer<StationEditDialog> dlg(new StationEditDialog(Session->m_Db, this));
     dlg->setStationInternalEditingEnabled(true);
     dlg->setStationExternalEditingEnabled(true);
     dlg->setStation(stId);
     int ret = dlg->exec();
-    if(!dlg)
-        return;
-    delete dlg;
-    if(ret != QDialog::Accepted)
+    if(!dlg || ret != QDialog::Accepted)
         return;
 
     //Refresh stations model
@@ -450,15 +445,11 @@ void StationsManager::onRemoveSegment()
 
 void StationsManager::onNewSegment()
 {
-    QPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(Session->m_Db, this));
+    OwningQPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(Session->m_Db, this));
     dlg->setSegment(0, EditRailwaySegmentDlg::DoNotLock, EditRailwaySegmentDlg::DoNotLock);
     int ret = dlg->exec();
 
-    if(!dlg)
-        return;
-    delete dlg;
-
-    if(ret != QDialog::Accepted)
+    if(ret != QDialog::Accepted || !dlg)
         return;
 
     //Re-calc row count
@@ -475,14 +466,11 @@ void StationsManager::onEditSegment()
     if(!segmentId)
         return;
 
-    QPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(Session->m_Db, this));
+    OwningQPointer<EditRailwaySegmentDlg> dlg(new EditRailwaySegmentDlg(Session->m_Db, this));
     dlg->setSegment(segmentId, EditRailwaySegmentDlg::DoNotLock, EditRailwaySegmentDlg::DoNotLock);
     int ret = dlg->exec();
-    if(!dlg)
-        return;
-    delete dlg;
 
-    if(ret != QDialog::Accepted)
+    if(ret != QDialog::Accepted || !dlg)
         return;
 
     //FIXME: check if actually changed
@@ -497,7 +485,7 @@ void StationsManager::onNewLine()
 {
     DEBUG_ENTRY;
 
-    QPointer<QInputDialog> dlg = new QInputDialog(this);
+    OwningQPointer<QInputDialog> dlg = new QInputDialog(this);
     dlg->setWindowTitle(tr("Add Line"));
     dlg->setLabelText(tr("Please choose a name for the new railway line."));
     dlg->setTextValue(QString());
@@ -522,8 +510,6 @@ void StationsManager::onNewLine()
         }
     }
     while (true);
-
-    delete dlg;
 
     //TODO
     //    QModelIndex idx = linesModel->index(row, 0);
@@ -556,14 +542,11 @@ void StationsManager::onEditLine()
     if(!lineId)
         return;
 
-    QPointer<EditLineDlg> dlg(new EditLineDlg(Session->m_Db, this));
+    OwningQPointer<EditLineDlg> dlg(new EditLineDlg(Session->m_Db, this));
     dlg->setLineId(lineId);
     int ret = dlg->exec();
-    if(!dlg)
-        return;
-    delete dlg;
 
-    if(ret != QDialog::Accepted)
+    if(ret != QDialog::Accepted || !dlg)
         return;
 
     //FIXME: check if actually changed

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MR_TIMETABLE_PLANNER_SOURCES
   utils/imageviewer.h
   utils/jobcategorystrings.h
   utils/kmutils.h
+  utils/owningqpointer.h
   utils/rs_types_names.h
   utils/rs_utils.h
   utils/session_rs_modes.h

--- a/src/utils/owningqpointer.h
+++ b/src/utils/owningqpointer.h
@@ -1,0 +1,27 @@
+#ifndef OWNINGQPOINTER_H
+#define OWNINGQPOINTER_H
+
+#include <QPointer>
+
+/*!
+ * QPointer tracks QObject instances and resets itself if they are deleted
+ * Meaning you will not get a dangling pointer.
+ * OwningQPointer adds ownership of tracked object by deleting it if still valid
+ * when the pointer goes out of scope
+ */
+template <typename T>
+class OwningQPointer : public QPointer<T>
+{
+public:
+    inline OwningQPointer(T *p) : QPointer<T>(p) { }
+    ~OwningQPointer();
+};
+
+template<typename T>
+OwningQPointer<T>::~OwningQPointer()
+{
+    if(this->data())
+        delete this->data();
+}
+
+#endif // OWNINGQPOINTER_H

--- a/src/viewmanager/sessionstartendrsviewer.cpp
+++ b/src/viewmanager/sessionstartendrsviewer.cpp
@@ -9,6 +9,7 @@
 
 #include <QFileDialog>
 #include <QStandardPaths>
+#include "utils/owningqpointer.h"
 
 #include "app/session.h"
 
@@ -77,20 +78,19 @@ void SessionStartEndRSViewer::modeChanged()
 
 void SessionStartEndRSViewer::exportSheet()
 {
-    QFileDialog dlg(this, tr("Expoert RS session plan"));
-    dlg.setFileMode(QFileDialog::AnyFile);
-    dlg.setAcceptMode(QFileDialog::AcceptSave);
-    dlg.setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+    OwningQPointer<QFileDialog> dlg = new QFileDialog(this, tr("Expoert RS session plan"));
+    dlg->setFileMode(QFileDialog::AnyFile);
+    dlg->setAcceptMode(QFileDialog::AcceptSave);
+    dlg->setDirectory(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
 
     QStringList filters;
     filters << FileFormats::tr(FileFormats::odtFormat);
-    dlg.setNameFilters(filters);
+    dlg->setNameFilters(filters);
 
-    if(dlg.exec() != QDialog::Accepted)
+    if(dlg->exec() != QDialog::Accepted || !dlg)
         return;
 
-    QString fileName = dlg.selectedUrls().value(0).toLocalFile();
-
+    QString fileName = dlg->selectedUrls().value(0).toLocalFile();
     if(fileName.isEmpty())
         return;
 


### PR DESCRIPTION
`QDialog` should be allocated on heap because if parent widget gets deleted while dialog is still open, being a children it will be deleted too.
Use `OwningQPointer` to track and delete dialog pointers