### PR TITLE
Fix odt export 2

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -2,17 +2,11 @@
 #include <QApplication>
 #include "app/session.h"
 
-#include <QTranslator>
+#include "utils/languageutils.h"
 
+#include <QTextStream>
 #include <QFile>
 #include <QDir>
-
-#include <QDebug>
-
-#include <QSettings>
-
-#include <QFile>
-#include <QTextStream>
 
 #include <QDateTime>
 
@@ -22,7 +16,7 @@
 
 #include <QMutex>
 
-#include <QStandardPaths>
+#include <QDebug>
 
 Q_GLOBAL_STATIC(QFile, gLogFile)
 static QtMessageHandler defaultHandler;
@@ -56,34 +50,6 @@ void myMessageOutput(QtMsgType type, const QMessageLogContext &context, const QS
     s << str;
 
     defaultHandler(type, context, msg);
-}
-
-void loadTranslations()
-{
-    QLocale locale = AppSettings.getLanguage();
-
-    qDebug() << "Locale:" << locale << locale.uiLanguages();
-
-    QString path = qApp->applicationDirPath() + QStringLiteral("/translations");
-    qDebug() << path;
-
-    QTranslator *translatorQt = new QTranslator(qApp);
-    if(translatorQt->load(locale,
-                          QStringLiteral("qt"), QStringLiteral("_"),
-                          path))
-    {
-        qDebug() << "Loading Qt translations";
-        qApp->installTranslator(translatorQt);
-    }
-
-    QTranslator *translator = new QTranslator(qApp);
-    if(translator->load(locale,
-                        QStringLiteral("mrtp"), QStringLiteral("_"),
-                        path))
-    {
-        qDebug() << "Loading UI translations";
-        qApp->installTranslator(translator);
-    }
 }
 
 void setupLogger()
@@ -145,7 +111,7 @@ int main(int argc, char *argv[])
     }
 
     MeetingSession meetingSession;
-    loadTranslations();
+    utils::language::loadTranslationsFromSettings();
 
     MainWindow w;
     w.showNormal();

--- a/src/app/session.cpp
+++ b/src/app/session.cpp
@@ -23,6 +23,8 @@
 #include <QStandardPaths>
 #include <QDir>
 
+#include <QTranslator>
+
 MeetingSession* MeetingSession::session;
 QString MeetingSession::appDataPath;
 
@@ -36,7 +38,8 @@ MeetingSession::MeetingSession() :
 
     jobLineWidth(6),
 
-    m_Db(nullptr)
+    m_Db(nullptr),
+    sheetExportTranslator(nullptr)
 {
     session = this; //Global singleton pointer
 
@@ -60,7 +63,8 @@ MeetingSession::MeetingSession() :
 
 MeetingSession::~MeetingSession()
 {
-
+    //Delete sheet export translator
+    setSheetExportTranslator(nullptr, sheetExportLocale);
 }
 
 MeetingSession *MeetingSession::Get()
@@ -733,6 +737,19 @@ void MeetingSession::locateAppdata()
     qDebug() << appDataPath;
 }
 
+void MeetingSession::setSheetExportTranslator(QTranslator *translator, const QLocale &loc)
+{
+    //NOTE: if Sheet Language is of Application Language then set a nullptr translator
+    //If translator is valid use it
+    //If translator is nullptr and language is default English locale, use hardcoded strings
+    //If translator is nullptr and language is different from English, use default translations
+
+    if(sheetExportTranslator && sheetExportTranslator != translator)
+        delete sheetExportTranslator;
+    sheetExportTranslator = translator;
+    sheetExportLocale = loc;
+}
+
 void MeetingSession::loadSettings(const QString& settings_file)
 {
     DEBUG_ENTRY;
@@ -749,6 +766,11 @@ void MeetingSession::loadSettings(const QString& settings_file)
     platformOffset = settings.getPlatformOffset();
 
     jobLineWidth = settings.getJobLineWidth();
+
+    originalAppLocale = settings.getLanguage();
+
+    //Default initialize to same value of application language
+    setSheetExportTranslator(nullptr, originalAppLocale);
 }
 
 #ifdef ENABLE_BACKGROUND_MANAGER

--- a/src/app/session.cpp
+++ b/src/app/session.cpp
@@ -27,6 +27,7 @@
 
 MeetingSession* MeetingSession::session;
 QString MeetingSession::appDataPath;
+const QLocale MeetingSession::embeddedLocale = QLocale(QLocale::English, QLocale::UnitedStates);
 
 MeetingSession::MeetingSession() :
     hourOffset(140),

--- a/src/app/session.h
+++ b/src/app/session.h
@@ -22,6 +22,8 @@ class MetaDataManager;
 class BackgroundManager;
 #endif
 
+class QTranslator;
+
 enum class DB_Error
 {
     NoError = 0,
@@ -33,7 +35,12 @@ enum class DB_Error
     FormatTooNew
 };
 
-
+/*!
+ * \brief The MeetingSession class
+ *
+ * This class is a singleton.
+ * It stores all informations about current loaded session and settings
+ */
 class MeetingSession : public QObject
 {
     Q_OBJECT
@@ -150,6 +157,52 @@ public:
 public:
     static void locateAppdata();
     static QString appDataPath;
+
+public:
+    /*!
+     * \brief sheetExportTranslator
+     *
+     * Custom translator for Sheet Export
+     * When it's valid it should be used before application translations
+     * When it's \c nullptr, application translations should be used
+     * Special case: when it's \c nullptr and \a sheetExportLocale is \c QLocale(QLocale::English)
+     * which is default language, then use hardcoded string literals and bypass any translation.
+     *
+     * \sa sheetExportLocale
+     * \sa setSheetExportTranslator()
+     */
+    QTranslator *sheetExportTranslator;
+
+    /*!
+     * \brief sheetExportLocale
+     *
+     * Locale for Sheet Export
+     * \sa sheetExportTranslator
+     */
+    QLocale sheetExportLocale;
+
+    /*!
+     * \brief originalAppLocale
+     * Store original language in which application was loaded
+     * When user changes Application Language in settings a restart
+     * is required to apply it but settings reports already new language.
+     * So use this variable to get original settings value before restart.
+     */
+    QLocale originalAppLocale;
+
+    /*!
+     * \brief setSheetExportTranslator
+     * \param translator
+     * \param loc
+     *
+     * Set translator for Sheet Export
+     * \sa sheetExportTranslator
+     */
+    void setSheetExportTranslator(QTranslator *translator, const QLocale& loc);
+
+    inline QTranslator *getSheetExportTranslator() const { return sheetExportTranslator; }
+    inline QLocale getSheetExportLocale() const { return sheetExportLocale; }
+    inline QLocale getAppLanguage() const { return originalAppLocale; }
 };
 
 #define Session MeetingSession::Get()

--- a/src/app/session.h
+++ b/src/app/session.h
@@ -158,7 +158,7 @@ public:
     static void locateAppdata();
     static QString appDataPath;
 
-public:
+private:
     /*!
      * \brief sheetExportTranslator
      *
@@ -198,6 +198,17 @@ public:
      * Set translator for Sheet Export
      * \sa sheetExportTranslator
      */
+
+public:
+    /*!
+     * \brief Embedded Locale
+     *
+     * This represents the QLocale of embedded strings (American English).
+     * This is the default Application Language if no translations are loaded
+     * If user choose this language no translations need to be loaded.
+     */
+    static const QLocale embeddedLocale;
+
     void setSheetExportTranslator(QTranslator *translator, const QLocale& loc);
 
     inline QTranslator *getSheetExportTranslator() const { return sheetExportTranslator; }

--- a/src/jobs/jobeditor/jobpatheditor.cpp
+++ b/src/jobs/jobeditor/jobpatheditor.cpp
@@ -26,6 +26,7 @@
 #include "shiftbusy/shiftbusymodel.h"
 
 #include "odt_export/jobsheetexport.h"
+#include "utils/openfileinfolder.h"
 
 #include "utils/file_format_names.h"
 
@@ -638,6 +639,8 @@ void JobPathEditor::onSaveSheet()
     JobSheetExport sheet(stopModel->getJobId(), stopModel->getCategory());
     sheet.write();
     sheet.save(fileName);
+
+    utils::OpenFileInFolderDlg::askUser(tr("Job Sheet Saved"), fileName, this);
 }
 
 void JobPathEditor::onIndexClicked(const QModelIndex& index)

--- a/src/jobs/jobeditor/jobpatheditor.cpp
+++ b/src/jobs/jobeditor/jobpatheditor.cpp
@@ -48,7 +48,7 @@ JobPathEditor::JobPathEditor(QWidget *parent) :
     catNames.reserve(int(JobCategory::NCategories));
     for(int cat = 0; cat < int(JobCategory::NCategories); cat++)
     {
-        catNames.append(JobCategoryName::tr(JobCategoryFullNameTable[cat]));
+        catNames.append(JobCategoryName::fullName(JobCategory(cat)));
     }
 
     ui->categoryCombo->addItems(catNames);

--- a/src/odt_export/common/jobwriter.cpp
+++ b/src/odt_export/common/jobwriter.cpp
@@ -144,6 +144,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Border: 0.05pt solid #000000 on left, top, bottom sides
      * Padding: 0.030cm all sides except bottom
      * padding-bottom: 0.15cm
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_5f_stops table: top left/middle cells (except top right which has H1 style)
@@ -170,6 +171,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Border: 0.05pt solid #000000 on all sides
      * Padding: 0.030cm all sides except bottom
      * padding-bottom: 0.15cm
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_5f_stops table: top right cell
@@ -184,6 +186,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:padding-top", "0.030cm");
     xml.writeAttribute("fo:padding-bottom", "0.15cm");
     xml.writeAttribute("fo:border", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -192,6 +195,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on left and bottom sides
      * Padding: 0.049cm all sides
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_5f_stops table: right and middle cells from second row to last row
@@ -206,6 +210,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "none");
     xml.writeAttribute("fo:border-top", "none");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -214,6 +219,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on left, right and bottom sides
      * Padding: 0.049cm all sides
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_5f_stops table: left cells from second row to last row
@@ -228,6 +234,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "0.05pt solid #000000");
     xml.writeAttribute("fo:border-top", "none");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -240,6 +247,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on left, top, bottom sides
      * Padding: 0.049cm
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_asset table: top left cell
@@ -262,6 +270,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on all sides
      * Padding: 0.049cm
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_asset table: top right cell
@@ -273,6 +282,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeStartElement("style:table-cell-properties");
     xml.writeAttribute("fo:padding", "0.049cm");
     xml.writeAttribute("fo:border", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -281,6 +291,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on right and bottom sides
      * Padding: 0.049cm
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_asset table: bottom left cell
@@ -295,6 +306,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "none");
     xml.writeAttribute("fo:border-top", "none");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -303,6 +315,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 all sides except top
      * Padding: 0.049cm
+     * Vertical Align: middle
      *
      * Usage:
      *  - job_asset table: bottom left cell
@@ -317,6 +330,7 @@ void JobWriter::writeJobAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "0.05pt solid #000000");
     xml.writeAttribute("fo:border-top", "none");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 }

--- a/src/odt_export/common/jobwriter.cpp
+++ b/src/odt_export/common/jobwriter.cpp
@@ -556,7 +556,7 @@ void JobWriter::writeJob(QXmlStreamWriter& xml, db_id jobId, JobCategory jobCat)
     //Title
     xml.writeStartElement("text:p");
     xml.writeAttribute("text:style-name", "P1");
-    xml.writeCharacters(JobCategoryName::jobName(jobId, jobCat));
+    xml.writeCharacters(JobCategoryName::jobNameSpaced(jobId, jobCat));
     xml.writeEndElement();
 
     //Vertical space

--- a/src/odt_export/common/jobwriter.cpp
+++ b/src/odt_export/common/jobwriter.cpp
@@ -37,9 +37,9 @@ void writeJobSummary(QXmlStreamWriter& xml,
     xml.writeStartElement("table:table-row");
 
     //Cells
-    writeCell(xml, "job_5f_summary_cell", "P2", Odt::tr("From:"));
+    writeCell(xml, "job_5f_summary_cell", "P2", Odt::text(Odt::jobSummaryFrom));
     writeCell(xml, "job_5f_summary_cell", "P3", from);
-    writeCell(xml, "job_5f_summary_cell", "P2", Odt::tr("Departure:"));
+    writeCell(xml, "job_5f_summary_cell", "P2", Odt::text(Odt::jobSummaryDep));
     writeCell(xml, "job_5f_summary_cell", "P3", dep);
 
     xml.writeEndElement(); //table-row
@@ -48,9 +48,9 @@ void writeJobSummary(QXmlStreamWriter& xml,
     xml.writeStartElement("table:table-row");
 
     //Cells
-    writeCell(xml, "job_5f_summary_cell", "P2", Odt::tr("To:"));
+    writeCell(xml, "job_5f_summary_cell", "P2", Odt::text(Odt::jobSummaryTo));
     writeCell(xml, "job_5f_summary_cell", "P3", to);
-    writeCell(xml, "job_5f_summary_cell", "P2", Odt::tr("Arrival:"));
+    writeCell(xml, "job_5f_summary_cell", "P2", Odt::text(Odt::jobSummaryArr));
     writeCell(xml, "job_5f_summary_cell", "P3", arr);
 
     xml.writeEndElement(); //table-row
@@ -59,7 +59,7 @@ void writeJobSummary(QXmlStreamWriter& xml,
     xml.writeStartElement("table:table-row");
 
     //Cells
-    writeCell(xml, "job_5f_summary_cell", "P2", Odt::tr("Axes:"));
+    writeCell(xml, "job_5f_summary_cell", "P2", Odt::text(Odt::jobSummaryAxes));
     writeCell(xml, "job_5f_summary_cell", "P3", QString::number(axes));
     writeCell(xml, "job_5f_summary_cell", "P2", QString());
     writeCell(xml, "job_5f_summary_cell", "P3", QString());
@@ -639,14 +639,14 @@ void JobWriter::writeJob(QXmlStreamWriter& xml, db_id jobId, JobCategory jobCat)
     xml.writeStartElement("table:table-row");
 
     const QString P4_Style = "P4";
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Station"));
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Arrival"));
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Departure"));
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Platf"));
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Rollingstock"));
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Crossings"));
-    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::tr("Passings"));
-    writeCell(xml, "job_5f_stops.H1", P4_Style, Odt::tr("Notes")); //Description
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::station));
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::arrival));
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::departure));
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::jobStopPlatf));
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::rollingstock));
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::jobStopCross));
+    writeCell(xml, "job_5f_stops.A1", P4_Style, Odt::text(Odt::jobStopPassings));
+    writeCell(xml, "job_5f_stops.H1", P4_Style, Odt::text(Odt::notes)); //Description
 
     xml.writeEndElement(); //end of row
     xml.writeEndElement(); //header section
@@ -725,7 +725,7 @@ void JobWriter::writeJob(QXmlStreamWriter& xml, db_id jobId, JobCategory jobCat)
                 //Use bold font
                 xml.writeStartElement("text:span");
                 xml.writeAttribute("text:style-name", "T1");
-                xml.writeCharacters(Odt::tr(Odt::CoupledAbbr));
+                xml.writeCharacters(Odt::text(Odt::CoupledAbbr));
                 xml.writeEndElement(); //test:span
             }
 
@@ -764,7 +764,7 @@ void JobWriter::writeJob(QXmlStreamWriter& xml, db_id jobId, JobCategory jobCat)
                 //Use bold font
                 xml.writeStartElement("text:span");
                 xml.writeAttribute("text:style-name", "T1");
-                xml.writeCharacters(Odt::tr(Odt::UncoupledAbbr));
+                xml.writeCharacters(Odt::text(Odt::UncoupledAbbr));
                 xml.writeEndElement(); //test:span
             }
 

--- a/src/odt_export/common/odtdocument.cpp
+++ b/src/odt_export/common/odtdocument.cpp
@@ -344,14 +344,14 @@ void OdtDocument::saveMeta(const QString& path)
             QString description;
             if(start != end)
             {
-                description = Odt::tr("Meeting in %1 from %2 to %3")
+                description = Odt::text(Odt::meetingFromTo)
                         .arg(meetingLocation)
                         .arg(start.toString("dd/MM/yyyy"))
                         .arg(end.toString("dd/MM/yyyy"));
             }
             else
             {
-                description = Odt::tr("Meeting in %1 on %2")
+                description = Odt::text(Odt::meetingOnDate)
                         .arg(meetingLocation)
                         .arg(start.toString("dd/MM/yyyy"));
             }
@@ -364,7 +364,7 @@ void OdtDocument::saveMeta(const QString& path)
 
     //Language
     xml.writeStartElement("dc:language");
-    xml.writeCharacters(AppSettings.getLanguage().bcp47Name());
+    xml.writeCharacters(Session->getSheetExportLocale().bcp47Name());
     xml.writeEndElement(); //dc:language
 
     //Generator
@@ -402,11 +402,11 @@ void OdtDocument::saveMeta(const QString& path)
     xml.writeEndElement(); //meta:keyword
 
     xml.writeStartElement("meta:keyword");
-    xml.writeCharacters(Odt::tr("Meeting"));
+    xml.writeCharacters(Odt::text(Odt::meeting));
     xml.writeEndElement(); //meta:keyword
 
     xml.writeStartElement("meta:keyword");
-    xml.writeCharacters("Meeting"); //Untranslated version
+    xml.writeCharacters(Odt::meeting[0]); //Untranslated version
     xml.writeEndElement(); //meta:keyword
 
     if(storeLocationAndDate && !meetingLocation.isEmpty())

--- a/src/odt_export/common/odtdocument.cpp
+++ b/src/odt_export/common/odtdocument.cpp
@@ -405,8 +405,9 @@ void OdtDocument::saveMeta(const QString& path)
     xml.writeCharacters(Odt::text(Odt::meeting));
     xml.writeEndElement(); //meta:keyword
 
+    //Untranslated version
     xml.writeStartElement("meta:keyword");
-    xml.writeCharacters(Odt::meeting[0]); //Untranslated version
+    xml.writeCharacters(QString::fromUtf8(Odt::meeting.sourceText));
     xml.writeEndElement(); //meta:keyword
 
     if(storeLocationAndDate && !meetingLocation.isEmpty())

--- a/src/odt_export/common/odtutils.cpp
+++ b/src/odt_export/common/odtutils.cpp
@@ -362,7 +362,7 @@ void writeLiberationFontFaces(QXmlStreamWriter &xml)
     writeFontFace(xml, liberationMono, liberationMono, "modern", "fixed");
 }
 
-QString Odt::text(const char * const str[2])
+QString Odt::text(const Text &t)
 {
     QTranslator *translator = Session->getSheetExportTranslator();
 
@@ -370,15 +370,15 @@ QString Odt::text(const char * const str[2])
     if(translator)
     {
         //Prefer selected language
-        result = translator->translate("Odt", str[0], str[1]);
+        result = translator->translate("Odt", t.sourceText, t.disambiguation);
     }
     else if(Session->getSheetExportLocale() == MeetingSession::embeddedLocale)
     {
         //Bypass any translation and use hardcoded string literals
-        return QString::fromUtf8(str[0]);
+        return QString::fromUtf8(t.sourceText);
     }
 
     if(result.isNull()) //Fallback to application language
-        result = tr(str[0], str[1]);
+        result = tr(t.sourceText, t.disambiguation);
     return result;
 }

--- a/src/odt_export/common/odtutils.cpp
+++ b/src/odt_export/common/odtutils.cpp
@@ -1,5 +1,8 @@
 #include "odtutils.h"
 
+#include "app/session.h"
+#include <QTranslator>
+
 /* writeColumnStyle
  *
  * Helper function to write table column style of a certain width
@@ -296,7 +299,7 @@ void writeHeaderFooter(QXmlStreamWriter &xml, const QString& headerText, const Q
     xml.writeStartElement("text:tab");
     xml.writeEndElement(); //text:tab
 
-    const QString pageStr = Odt::tr("Page ");
+    const QString pageStr = Odt::text(Odt::headerPage);
 
     xml.writeCharacters(pageStr);
 
@@ -357,4 +360,25 @@ void writeLiberationFontFaces(QXmlStreamWriter &xml)
     writeFontFace(xml, liberationSerif, liberationSerif, "roman", variablePitch);
     writeFontFace(xml, liberationSans, liberationSans, "swiss", variablePitch);
     writeFontFace(xml, liberationMono, liberationMono, "modern", "fixed");
+}
+
+QString Odt::text(const char * const str[2])
+{
+    QTranslator *translator = Session->getSheetExportTranslator();
+
+    QString result;
+    if(translator)
+    {
+        //Prefer selected language
+        result = translator->translate("Odt", str[0], str[1]);
+    }
+    else if(Session->getSheetExportLocale() == MeetingSession::embeddedLocale)
+    {
+        //Bypass any translation and use hardcoded string literals
+        return QString::fromUtf8(str[0]);
+    }
+
+    if(result.isNull()) //Fallback to application language
+        result = tr(str[0], str[1]);
+    return result;
 }

--- a/src/odt_export/common/odtutils.h
+++ b/src/odt_export/common/odtutils.h
@@ -66,65 +66,75 @@ class Odt
 {
     Q_DECLARE_TR_FUNCTIONS(Odt)
 public:
-    static QString text(const char * const str[2]);
+    struct Text
+    {
+        const char *sourceText;
+        const char *disambiguation;
+    };
+
+    static QString text(const Text& t);
 
 public:
     //Header/Footer
-    static constexpr const char *headerPage[] = QT_TRANSLATE_NOOP3("Odt", "Page ", "Header page, leave space at end, page number will be added");
+    static constexpr Text headerPage = QT_TRANSLATE_NOOP3("Odt", "Page ",
+                                                          "Header page, leave space at end, page number will be added");
 
     //Meeting
-    static constexpr const char *meeting[]       = QT_TRANSLATE_NOOP3("Odt", "Meeting", "Document keywords");
-    static constexpr const char *meetingFromTo[] = QT_TRANSLATE_NOOP3("Odt", "Meeting in %1 from %2 to %3", "Document description, where, from date, to date");
-    static constexpr const char *meetingOnDate[] = QT_TRANSLATE_NOOP3("Odt", "Meeting in %1 on %2",         "Document description, where, when");
-    static constexpr const char *meetingFromToShort[] = QT_TRANSLATE_NOOP3("Odt", "From %1 to %2", "Shift cover, meeting from date, to date");
+    static constexpr Text meeting       = QT_TRANSLATE_NOOP3("Odt", "Meeting", "Document keywords");
+    static constexpr Text meetingFromTo = QT_TRANSLATE_NOOP3("Odt", "Meeting in %1 from %2 to %3",
+                                                             "Document description, where, from date, to date");
+    static constexpr Text meetingOnDate = QT_TRANSLATE_NOOP3("Odt", "Meeting in %1 on %2",
+                                                             "Document description, where, when");
+    static constexpr Text meetingFromToShort = QT_TRANSLATE_NOOP3("Odt", "From %1 to %2",
+                                                                  "Shift cover, meeting from date, to date");
 
     //Rollingstock
-    static constexpr const char *CoupledAbbr[]    = QT_TRANSLATE_NOOP3("Odt", "Cp:",  "Job stop coupled RS");
-    static constexpr const char *UncoupledAbbr[]  = QT_TRANSLATE_NOOP3("Odt", "Unc:", "Job stop uncoupled RS");
-    static constexpr const char *genericRSOwner[] = QT_TRANSLATE_NOOP3("Odt", "Owner", "Rollingstock Owner");
+    static constexpr Text CoupledAbbr    = QT_TRANSLATE_NOOP3("Odt", "Cp:",   "Job stop coupled RS");
+    static constexpr Text UncoupledAbbr  = QT_TRANSLATE_NOOP3("Odt", "Unc:",  "Job stop uncoupled RS");
+    static constexpr Text genericRSOwner = QT_TRANSLATE_NOOP3("Odt", "Owner", "Rollingstock Owner");
 
-    static constexpr const char *rsSessionTitle[] = QT_TRANSLATE_NOOP3("Odt", "Rollingstock by %1 at %2 of session",
-                                                                       "Rollingstock Session title, 1 is Owner/Station and 2 is start/end");
-    static constexpr const char *rsSessionStart[] = QT_TRANSLATE_NOOP3("Odt", "start", "Rollingstock Session start");
-    static constexpr const char *rsSessionEnd[]   = QT_TRANSLATE_NOOP3("Odt", "end", "Rollingstock Session end");
+    static constexpr Text rsSessionTitle = QT_TRANSLATE_NOOP3("Odt", "Rollingstock by %1 at %2 of session",
+                                                              "Rollingstock Session title, 1 is Owner/Station and 2 is start/end");
+    static constexpr Text rsSessionStart = QT_TRANSLATE_NOOP3("Odt", "start", "Rollingstock Session start");
+    static constexpr Text rsSessionEnd   = QT_TRANSLATE_NOOP3("Odt", "end",   "Rollingstock Session end");
 
     //Job Summary
-    static constexpr const char *jobSummaryFrom[] = QT_TRANSLATE_NOOP3("Odt", "From:",      "Job summary");
-    static constexpr const char *jobSummaryTo[]   = QT_TRANSLATE_NOOP3("Odt", "To:",        "Job summary");
-    static constexpr const char *jobSummaryDep[]  = QT_TRANSLATE_NOOP3("Odt", "Departure:", "Job summary");
-    static constexpr const char *jobSummaryArr[]  = QT_TRANSLATE_NOOP3("Odt", "Arrival:",   "Job summary");
-    static constexpr const char *jobSummaryAxes[] = QT_TRANSLATE_NOOP3("Odt", "Axes:",      "Job summary");
+    static constexpr Text jobSummaryFrom = QT_TRANSLATE_NOOP3("Odt", "From:",      "Job summary");
+    static constexpr Text jobSummaryTo   = QT_TRANSLATE_NOOP3("Odt", "To:",        "Job summary");
+    static constexpr Text jobSummaryDep  = QT_TRANSLATE_NOOP3("Odt", "Departure:", "Job summary");
+    static constexpr Text jobSummaryArr  = QT_TRANSLATE_NOOP3("Odt", "Arrival:",   "Job summary");
+    static constexpr Text jobSummaryAxes = QT_TRANSLATE_NOOP3("Odt", "Axes:",      "Job summary");
 
     //Job Stops Header
-    static constexpr const char *station[]      = QT_TRANSLATE_NOOP3("Odt", "Station",      "Job stop table");
-    static constexpr const char *stationPageTitle[] = QT_TRANSLATE_NOOP3("Odt", "Station: %1",  "Station title in station sheet");
-    static constexpr const char *stationDocTitle[]  = QT_TRANSLATE_NOOP3("Odt", "%1 station",  "Station sheet title in document metadata");
-    static constexpr const char *rollingstock[] = QT_TRANSLATE_NOOP3("Odt", "Rollingstock", "Job stop table");
-    static constexpr const char *jobNr[]        = QT_TRANSLATE_NOOP3("Odt", "Job Nr",       "Job column");
+    static constexpr Text station      = QT_TRANSLATE_NOOP3("Odt", "Station",      "Job stop table");
+    static constexpr Text stationPageTitle = QT_TRANSLATE_NOOP3("Odt", "Station: %1",  "Station title in station sheet");
+    static constexpr Text stationDocTitle  = QT_TRANSLATE_NOOP3("Odt", "%1 station",   "Station sheet title in document metadata");
+    static constexpr Text rollingstock = QT_TRANSLATE_NOOP3("Odt", "Rollingstock", "Job stop table");
+    static constexpr Text jobNr        = QT_TRANSLATE_NOOP3("Odt", "Job Nr",       "Job column");
 
-    static constexpr const char *arrival[]   = QT_TRANSLATE_NOOP3("Odt", "Arrival",   "Job stop table");
-    static constexpr const char *departure[] = QT_TRANSLATE_NOOP3("Odt", "Departure", "Job stop table");
-    static constexpr const char *arrivalShort[]   = QT_TRANSLATE_NOOP3("Odt", "Arr.", "Arrival abbreviated");
-    static constexpr const char *departureShort[] = QT_TRANSLATE_NOOP3("Odt", "Dep.", "Departure abbreviated");
+    static constexpr Text arrival   = QT_TRANSLATE_NOOP3("Odt", "Arrival",   "Job stop table");
+    static constexpr Text departure = QT_TRANSLATE_NOOP3("Odt", "Departure", "Job stop table");
+    static constexpr Text arrivalShort   = QT_TRANSLATE_NOOP3("Odt", "Arr.", "Arrival abbreviated");
+    static constexpr Text departureShort = QT_TRANSLATE_NOOP3("Odt", "Dep.", "Departure abbreviated");
 
-    static constexpr const char *stationFromCol[] = QT_TRANSLATE_NOOP3("Odt", "From", "Station stop table, From previous station column");
-    static constexpr const char *stationToCol[]   = QT_TRANSLATE_NOOP3("Odt", "To",   "Station stop table, To next station column");
+    static constexpr Text stationFromCol = QT_TRANSLATE_NOOP3("Odt", "From", "Station stop table, From previous station column");
+    static constexpr Text stationToCol   = QT_TRANSLATE_NOOP3("Odt", "To",   "Station stop table, To next station column");
 
-    static constexpr const char *jobStopPlatf[] = QT_TRANSLATE_NOOP3("Odt", "Platf", "Job stop table, platform abbreviated");
-    static constexpr const char *jobStopIsTransit[] = QT_TRANSLATE_NOOP3("Odt", "Transit", "Job stop table, notes column");
-    static constexpr const char *jobStopIsFirst[] = QT_TRANSLATE_NOOP3("Odt", "START",
+    static constexpr Text jobStopPlatf     = QT_TRANSLATE_NOOP3("Odt", "Platf",   "Job stop table, platform abbreviated");
+    static constexpr Text jobStopIsTransit = QT_TRANSLATE_NOOP3("Odt", "Transit", "Job stop table, notes column");
+    static constexpr Text jobStopIsFirst   = QT_TRANSLATE_NOOP3("Odt", "START",
                                                                        "Station stop table, notes column for first job stop, "
                                                                        "keep in English it's the same for every sheet");
 
-    static constexpr const char *jobStopCross[]    = QT_TRANSLATE_NOOP3("Odt", "Crossings",  "Job stop table");
-    static constexpr const char *jobStopPassings[] = QT_TRANSLATE_NOOP3("Odt", "Passings", "Job stop table");
-    static constexpr const char *jobStopCrossShort[]    = QT_TRANSLATE_NOOP3("Odt", "Cross",  "Job stop crossings abbreviated column");
-    static constexpr const char *jobStopPassingsShort[] = QT_TRANSLATE_NOOP3("Odt", "Passes", "Job stop passings abbreviated column");
-    static constexpr const char *notes[] = QT_TRANSLATE_NOOP3("Odt", "Notes", "Job stop table");
+    static constexpr Text jobStopCross    = QT_TRANSLATE_NOOP3("Odt", "Crossings",  "Job stop table");
+    static constexpr Text jobStopPassings = QT_TRANSLATE_NOOP3("Odt", "Passings",   "Job stop table");
+    static constexpr Text jobStopCrossShort    = QT_TRANSLATE_NOOP3("Odt", "Cross",  "Job stop crossings abbreviated column");
+    static constexpr Text jobStopPassingsShort = QT_TRANSLATE_NOOP3("Odt", "Passes", "Job stop passings abbreviated column");
+    static constexpr Text notes = QT_TRANSLATE_NOOP3("Odt", "Notes", "Job stop table");
 
     //Shift
-    static constexpr const char *shiftCoverTitle[] = QT_TRANSLATE_NOOP3("Odt", "SHIFT %1", "Shift title in shift sheet cover");
-    static constexpr const char *shiftDocTitle[]   = QT_TRANSLATE_NOOP3("Odt", "Shift %1", "Shift sheet document title for metadata");
+    static constexpr Text shiftCoverTitle = QT_TRANSLATE_NOOP3("Odt", "SHIFT %1", "Shift title in shift sheet cover");
+    static constexpr Text shiftDocTitle   = QT_TRANSLATE_NOOP3("Odt", "Shift %1", "Shift sheet document title for metadata");
 };
 
 #endif // ODTUTILS_H

--- a/src/odt_export/common/odtutils.h
+++ b/src/odt_export/common/odtutils.h
@@ -66,8 +66,65 @@ class Odt
 {
     Q_DECLARE_TR_FUNCTIONS(Odt)
 public:
-    static constexpr const char *CoupledAbbr = QT_TRANSLATE_NOOP("Odt", "Cp:");
-    static constexpr const char *UncoupledAbbr = QT_TRANSLATE_NOOP("Odt", "Unc:");
+    static QString text(const char * const str[2]);
+
+public:
+    //Header/Footer
+    static constexpr const char *headerPage[] = QT_TRANSLATE_NOOP3("Odt", "Page ", "Header page, leave space at end, page number will be added");
+
+    //Meeting
+    static constexpr const char *meeting[]       = QT_TRANSLATE_NOOP3("Odt", "Meeting", "Document keywords");
+    static constexpr const char *meetingFromTo[] = QT_TRANSLATE_NOOP3("Odt", "Meeting in %1 from %2 to %3", "Document description, where, from date, to date");
+    static constexpr const char *meetingOnDate[] = QT_TRANSLATE_NOOP3("Odt", "Meeting in %1 on %2",         "Document description, where, when");
+    static constexpr const char *meetingFromToShort[] = QT_TRANSLATE_NOOP3("Odt", "From %1 to %2", "Shift cover, meeting from date, to date");
+
+    //Rollingstock
+    static constexpr const char *CoupledAbbr[]    = QT_TRANSLATE_NOOP3("Odt", "Cp:",  "Job stop coupled RS");
+    static constexpr const char *UncoupledAbbr[]  = QT_TRANSLATE_NOOP3("Odt", "Unc:", "Job stop uncoupled RS");
+    static constexpr const char *genericRSOwner[] = QT_TRANSLATE_NOOP3("Odt", "Owner", "Rollingstock Owner");
+
+    static constexpr const char *rsSessionTitle[] = QT_TRANSLATE_NOOP3("Odt", "Rollingstock by %1 at %2 of session",
+                                                                       "Rollingstock Session title, 1 is Owner/Station and 2 is start/end");
+    static constexpr const char *rsSessionStart[] = QT_TRANSLATE_NOOP3("Odt", "start", "Rollingstock Session start");
+    static constexpr const char *rsSessionEnd[]   = QT_TRANSLATE_NOOP3("Odt", "end", "Rollingstock Session end");
+
+    //Job Summary
+    static constexpr const char *jobSummaryFrom[] = QT_TRANSLATE_NOOP3("Odt", "From:",      "Job summary");
+    static constexpr const char *jobSummaryTo[]   = QT_TRANSLATE_NOOP3("Odt", "To:",        "Job summary");
+    static constexpr const char *jobSummaryDep[]  = QT_TRANSLATE_NOOP3("Odt", "Departure:", "Job summary");
+    static constexpr const char *jobSummaryArr[]  = QT_TRANSLATE_NOOP3("Odt", "Arrival:",   "Job summary");
+    static constexpr const char *jobSummaryAxes[] = QT_TRANSLATE_NOOP3("Odt", "Axes:",      "Job summary");
+
+    //Job Stops Header
+    static constexpr const char *station[]      = QT_TRANSLATE_NOOP3("Odt", "Station",      "Job stop table");
+    static constexpr const char *stationPageTitle[] = QT_TRANSLATE_NOOP3("Odt", "Station: %1",  "Station title in station sheet");
+    static constexpr const char *stationDocTitle[]  = QT_TRANSLATE_NOOP3("Odt", "%1 station",  "Station sheet title in document metadata");
+    static constexpr const char *rollingstock[] = QT_TRANSLATE_NOOP3("Odt", "Rollingstock", "Job stop table");
+    static constexpr const char *jobNr[]        = QT_TRANSLATE_NOOP3("Odt", "Job Nr",       "Job column");
+
+    static constexpr const char *arrival[]   = QT_TRANSLATE_NOOP3("Odt", "Arrival",   "Job stop table");
+    static constexpr const char *departure[] = QT_TRANSLATE_NOOP3("Odt", "Departure", "Job stop table");
+    static constexpr const char *arrivalShort[]   = QT_TRANSLATE_NOOP3("Odt", "Arr.", "Arrival abbreviated");
+    static constexpr const char *departureShort[] = QT_TRANSLATE_NOOP3("Odt", "Dep.", "Departure abbreviated");
+
+    static constexpr const char *stationFromCol[] = QT_TRANSLATE_NOOP3("Odt", "From", "Station stop table, From previous station column");
+    static constexpr const char *stationToCol[]   = QT_TRANSLATE_NOOP3("Odt", "To",   "Station stop table, To next station column");
+
+    static constexpr const char *jobStopPlatf[] = QT_TRANSLATE_NOOP3("Odt", "Platf", "Job stop table, platform abbreviated");
+    static constexpr const char *jobStopIsTransit[] = QT_TRANSLATE_NOOP3("Odt", "Transit", "Job stop table, notes column");
+    static constexpr const char *jobStopIsFirst[] = QT_TRANSLATE_NOOP3("Odt", "START",
+                                                                       "Station stop table, notes column for first job stop, "
+                                                                       "keep in English it's the same for every sheet");
+
+    static constexpr const char *jobStopCross[]    = QT_TRANSLATE_NOOP3("Odt", "Crossings",  "Job stop table");
+    static constexpr const char *jobStopPassings[] = QT_TRANSLATE_NOOP3("Odt", "Passings", "Job stop table");
+    static constexpr const char *jobStopCrossShort[]    = QT_TRANSLATE_NOOP3("Odt", "Cross",  "Job stop crossings abbreviated column");
+    static constexpr const char *jobStopPassingsShort[] = QT_TRANSLATE_NOOP3("Odt", "Passes", "Job stop passings abbreviated column");
+    static constexpr const char *notes[] = QT_TRANSLATE_NOOP3("Odt", "Notes", "Job stop table");
+
+    //Shift
+    static constexpr const char *shiftCoverTitle[] = QT_TRANSLATE_NOOP3("Odt", "SHIFT %1", "Shift title in shift sheet cover");
+    static constexpr const char *shiftDocTitle[]   = QT_TRANSLATE_NOOP3("Odt", "Shift %1", "Shift sheet document title for metadata");
 };
 
 #endif // ODTUTILS_H

--- a/src/odt_export/common/sessionrswriter.cpp
+++ b/src/odt_export/common/sessionrswriter.cpp
@@ -243,11 +243,11 @@ db_id SessionRSWriter::writeTable(QXmlStreamWriter &xml, const QString& parentNa
     const QString P4_style = QStringLiteral("P4");
     const QString P5_style = QStringLiteral("P5");
     //Cells (column names, headings)
-    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::tr("Rollingstock"));
-    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::tr("Job"));
-    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::tr("Platf"));
-    writeCell(xml, "rs_5f_table.A1", P4_style, m_mode == SessionRSMode::StartOfSession ? Odt::tr("Departure") : Odt::tr("Arrival"));
-    writeCell(xml, "rs_5f_table.E1", P4_style, m_order == SessionRSOrder::ByStation ? Odt::tr("Owner") : Odt::tr("Station"));
+    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::text(Odt::rollingstock));
+    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::text(Odt::jobNr));
+    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::text(Odt::jobStopPlatf));
+    writeCell(xml, "rs_5f_table.A1", P4_style, Odt::text(m_mode == SessionRSMode::StartOfSession ? Odt::departure : Odt::arrival));
+    writeCell(xml, "rs_5f_table.E1", P4_style, Odt::text(m_order == SessionRSOrder::ByStation ? Odt::genericRSOwner : Odt::station));
 
     xml.writeEndElement(); //end of row
     xml.writeEndElement(); //header section
@@ -334,8 +334,8 @@ void SessionRSWriter::writeContent(QXmlStreamWriter &xml)
 
 QString SessionRSWriter::generateTitle() const
 {
-    QString title = Odt::tr("Rollingstock by %1 at %2 of session")
-            .arg(m_order == SessionRSOrder::ByOwner ? Odt::tr("Owner") : Odt::tr("Station"))
-            .arg(m_mode == SessionRSMode::StartOfSession ? Odt::tr("start") : Odt::tr("end"));
+    QString title = Odt::text(Odt::rsSessionTitle).arg(
+        Odt::text(m_order == SessionRSOrder::ByStation ? Odt::genericRSOwner : Odt::station),
+        Odt::text(m_mode == SessionRSMode::StartOfSession ? Odt::rsSessionStart : Odt::rsSessionEnd));
     return title;
 }

--- a/src/odt_export/common/stationwriter.cpp
+++ b/src/odt_export/common/stationwriter.cpp
@@ -595,13 +595,27 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
 
         //Description, Notes
         writeCellListStart(xml, "stationtable.L2", "P3");
+        bool needsLineBreak = false;
         if(isTransit)
         {
             xml.writeCharacters(Odt::tr("Transit"));
+            needsLineBreak = true;
+        }
+        if(stop.prevSt.isEmpty())
+        {
+            if(needsLineBreak)
+                xml.writeEmptyElement("text:line-break");
+
+            //This is Origin (First stop), use Bold font
+            xml.writeStartElement("text:span");
+            xml.writeAttribute("text:style-name", "T1");
+            xml.writeCharacters(Odt::tr("START", "Do not translate this text"));
+            xml.writeEndElement(); //test:span
+            needsLineBreak = true;
         }
         if(!stop.description.isEmpty())
         {
-            if(isTransit) //go to new line after 'Transit' word
+            if(needsLineBreak) //go to new line after 'Transit' word
                 xml.writeEmptyElement("text:line-break");
 
             //Split in lines
@@ -621,9 +635,9 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
 
         xml.writeEndElement(); //table-row
 
-        if(!isTransit)
+        if(!isTransit && !stop.prevSt.isEmpty() && !stop.nextSt.isEmpty())
         {
-            //If it is a normal stop (not a transit)
+            //If it is a normal stop (not a transit and not first stop or last stop)
             //insert two rows: one for arrival and another
             //that reminds the station master (capostazione)
             //the departure of that train

--- a/src/odt_export/common/stationwriter.cpp
+++ b/src/odt_export/common/stationwriter.cpp
@@ -319,12 +319,18 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
     if(stNameOut)
         *stNameOut = stationName;
 
-    const QString shortNameStr = shortName.isEmpty() ? QString() : Odt::tr(" (%1)").arg(shortName);
+    QString stationNameStr = stationName;
+    if(!shortName.isEmpty())
+    {
+        stationNameStr.append(QLatin1String(" ("));
+        stationNameStr.append(shortName);
+        stationNameStr.append(')');
+    }
 
     //Title
     xml.writeStartElement("text:p");
     xml.writeAttribute("text:style-name", "P1");
-    xml.writeCharacters(Odt::tr("Station: %1%2").arg(stationName, shortNameStr));
+    xml.writeCharacters(Odt::text(Odt::stationPageTitle).arg(stationNameStr));
     xml.writeEndElement();
 
     //Vertical space
@@ -371,16 +377,16 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
     xml.writeStartElement("table:table-header-rows");
     xml.writeStartElement("table:table-row");
 
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Arr.", "Arrival column"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Dep.", "Departure column"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Job Nr"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Platf"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("From"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("To"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Rollingstock"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Cross", "Crossings column"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Passings", "Passings column"));
-    writeCell(xml, "stationtable.L1", "P2", Odt::tr("Notes")); //Description
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::arrivalShort));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::departureShort));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::jobNr));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::jobStopPlatf));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::stationFromCol));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::stationToCol));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::rollingstock));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::jobStopCrossShort));
+    writeCell(xml, "stationtable.A1", "P2", Odt::text(Odt::jobStopPassingsShort));
+    writeCell(xml, "stationtable.L1", "P2", Odt::text(Odt::notes)); //Description
 
     xml.writeEndElement(); //end of row
     xml.writeEndElement(); //header section
@@ -491,7 +497,7 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
                 //Use bold font
                 xml.writeStartElement("text:span");
                 xml.writeAttribute("text:style-name", "T1");
-                xml.writeCharacters(Odt::tr(Odt::CoupledAbbr));
+                xml.writeCharacters(Odt::text(Odt::CoupledAbbr));
                 xml.writeEndElement(); //test:span
             }
 
@@ -530,7 +536,7 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
                 //Use bold font
                 xml.writeStartElement("text:span");
                 xml.writeAttribute("text:style-name", "T1");
-                xml.writeCharacters(Odt::tr(Odt::UncoupledAbbr));
+                xml.writeCharacters(Odt::text(Odt::UncoupledAbbr));
                 xml.writeEndElement(); //test:span
             }
 
@@ -596,7 +602,7 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
         bool needsLineBreak = false;
         if(isTransit)
         {
-            xml.writeCharacters(Odt::tr("Transit"));
+            xml.writeCharacters(Odt::text(Odt::jobStopIsTransit));
             needsLineBreak = true;
         }
         if(stop.prevSt.isEmpty())
@@ -607,7 +613,7 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
             //This is Origin (First stop), use Bold font
             xml.writeStartElement("text:span");
             xml.writeAttribute("text:style-name", "T1");
-            xml.writeCharacters(Odt::tr("START", "Do not translate this text"));
+            xml.writeCharacters(Odt::text(Odt::jobStopIsFirst));
             xml.writeEndElement(); //test:span
             needsLineBreak = true;
         }

--- a/src/odt_export/common/stationwriter.cpp
+++ b/src/odt_export/common/stationwriter.cpp
@@ -319,14 +319,12 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
     if(stNameOut)
         *stNameOut = stationName;
 
+    const QString shortNameStr = shortName.isEmpty() ? QString() : Odt::tr(" (%1)").arg(shortName);
+
     //Title
     xml.writeStartElement("text:p");
     xml.writeAttribute("text:style-name", "P1");
-    xml.writeCharacters(Odt::tr("Station: %1%2")
-                            .arg(stationName)
-                            .arg(shortName.isEmpty() ?
-                                     QString() :
-                                     Odt::tr(" (%1)").arg(shortName)));
+    xml.writeCharacters(Odt::tr("Station: %1%2").arg(stationName, shortNameStr));
     xml.writeEndElement();
 
     //Vertical space
@@ -373,15 +371,15 @@ void StationWriter::writeStation(QXmlStreamWriter &xml, db_id stationId, QString
     xml.writeStartElement("table:table-header-rows");
     xml.writeStartElement("table:table-row");
 
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Arrival"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Departure"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Job N"));
+    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Arr.", "Arrival column"));
+    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Dep.", "Departure column"));
+    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Job Nr"));
     writeCell(xml, "stationtable.A1", "P2", Odt::tr("Platf"));
     writeCell(xml, "stationtable.A1", "P2", Odt::tr("From"));
     writeCell(xml, "stationtable.A1", "P2", Odt::tr("To"));
     writeCell(xml, "stationtable.A1", "P2", Odt::tr("Rollingstock"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Crossings"));
-    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Passings"));
+    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Cross", "Crossings column"));
+    writeCell(xml, "stationtable.A1", "P2", Odt::tr("Passings", "Passings column"));
     writeCell(xml, "stationtable.L1", "P2", Odt::tr("Notes")); //Description
 
     xml.writeEndElement(); //end of row

--- a/src/odt_export/common/stationwriter.cpp
+++ b/src/odt_export/common/stationwriter.cpp
@@ -130,6 +130,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on left, top, bottom sides
      * Padding: 0.097cm all sides
+     * Vertical Align: middle
      *
      * Usage:
      *  - stationtable table: top left/middle cells (except top right which has L1 style)
@@ -144,6 +145,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "none");
     xml.writeAttribute("fo:border-top", "0.05pt solid #000000");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -152,6 +154,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on all sides
      * Padding: 0.097cm all sides
+     * Vertical Align: middle
      *
      * Usage:
      *  - stationtable table: top right cell
@@ -163,6 +166,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeStartElement("style:table-cell-properties");
     xml.writeAttribute("fo:border", "0.05pt solid #000000");
     xml.writeAttribute("fo:padding", "0.097cm");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -171,6 +175,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on left and bottom sides
      * Padding: 0.097cm all sides
+     * Vertical Align: middle
      *
      * Usage:
      *  - stationtable table: right and middle cells from second row to last row
@@ -185,6 +190,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "none");
     xml.writeAttribute("fo:border-top", "none");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 
@@ -193,6 +199,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
      * Type: table-cell
      * Border: 0.05pt solid #000000 on left, right and bottom sides
      * Padding: 0.097cm all sides
+     * Vertical Align: middle
      *
      * Usage:
      *  - stationtable table: left cells from second row to last row
@@ -207,6 +214,7 @@ void StationWriter::writeStationAutomaticStyles(QXmlStreamWriter &xml)
     xml.writeAttribute("fo:border-right", "0.05pt solid #000000");
     xml.writeAttribute("fo:border-top", "none");
     xml.writeAttribute("fo:border-bottom", "0.05pt solid #000000");
+    xml.writeAttribute("style:vertical-align", "middle");
     xml.writeEndElement(); //style:table-cell-properties
     xml.writeEndElement(); //style
 

--- a/src/odt_export/shiftsheetexport.cpp
+++ b/src/odt_export/shiftsheetexport.cpp
@@ -107,10 +107,12 @@ void ShiftSheetExport::write()
 
     JobWriter w(mDb);
 
-    q.prepare("SELECT jobs.id,jobs.category,s1.arrival"
+    q.prepare("SELECT jobs.id,jobs.category,MIN(s1.arrival)"
               " FROM jobs"
-              " JOIN stops s1 ON s1.id=jobs.firstStop"
-              " WHERE jobs.shiftId=? ORDER BY s1.arrival ASC");
+              " JOIN stops s1 ON s1.job_id=jobs.id"
+              " WHERE jobs.shift_id=?"
+              " GROUP BY jobs.id"
+              " ORDER BY s1.arrival ASC");
     q.bind(1, m_shiftId);
     for(auto r : q)
     {

--- a/src/odt_export/shiftsheetexport.cpp
+++ b/src/odt_export/shiftsheetexport.cpp
@@ -101,7 +101,7 @@ void ShiftSheetExport::write()
 
     shiftName = q.getRows().get<QString>(0);
 
-    odt.setTitle(Odt::tr("Shift %1").arg(shiftName));
+    odt.setTitle(Odt::text(Odt::shiftDocTitle).arg(shiftName));
 
     writeCover(odt.contentXml, shiftName, hasLogo);
 
@@ -419,7 +419,7 @@ void ShiftSheetExport::writeCover(QXmlStreamWriter& xml, const QString& shiftNam
             if(start == end)
                 xml.writeCharacters(start.toString("dd/MM/yyyy"));
             else
-                xml.writeCharacters(Odt::tr("From %1 to %2")
+                xml.writeCharacters(Odt::text(Odt::meetingFromToShort)
                                     .arg(start.toString("dd/MM/yyyy"))
                                     .arg(end.toString("dd/MM/yyyy")));
             xml.writeEndElement();
@@ -478,7 +478,7 @@ void ShiftSheetExport::writeCover(QXmlStreamWriter& xml, const QString& shiftNam
     //Shift name
     xml.writeStartElement("text:p");
     xml.writeAttribute("text:style-name", "shift_name_style");
-    xml.writeCharacters(Odt::tr("SHIFT %1").arg(shiftName));
+    xml.writeCharacters(Odt::text(Odt::shiftCoverTitle).arg(shiftName));
     xml.writeEndElement();
     str.clear();
 

--- a/src/odt_export/stationsheetexport.cpp
+++ b/src/odt_export/stationsheetexport.cpp
@@ -73,7 +73,7 @@ void StationSheetExport::write()
     StationWriter w(Session->m_Db);
     QString stName;
     w.writeStation(odt.contentXml, m_stationId, &stName);
-    odt.setTitle(Odt::tr("%1 station").arg(stName));
+    odt.setTitle(Odt::text(Odt::stationDocTitle).arg(stName));
 
     odt.endDocument();
 }

--- a/src/odt_export/stationsheetexport.h
+++ b/src/odt_export/stationsheetexport.h
@@ -5,7 +5,6 @@
 
 #include "utils/types.h"
 
-//TODO: implement, deprecate MeetingSession API
 class StationSheetExport
 {
 public:

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(MR_TIMETABLE_PLANNER_SOURCES
   ${MR_TIMETABLE_PLANNER_SOURCES}
   settings/appsettings.h
+  settings/languagemodel.h
   settings/settingsdialog.h
   settings/type_utils.h
 
   settings/appsettings.cpp
+  settings/languagemodel.cpp
   settings/settingsdialog.cpp
   PARENT_SCOPE
 )

--- a/src/settings/languagemodel.cpp
+++ b/src/settings/languagemodel.cpp
@@ -1,0 +1,87 @@
+#include "languagemodel.h"
+
+#include "utils/languageutils.h"
+
+LanguageModel::LanguageModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+QVariant LanguageModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Horizontal && role == Qt::DisplayRole)
+    {
+        if(section == 0)
+            return tr("Language");
+    }
+
+    return QAbstractListModel::headerData(section, orientation, role);
+}
+
+int LanguageModel::rowCount(const QModelIndex &p) const
+{
+    return p.isValid() ? 0 : m_data.size();
+}
+
+QVariant LanguageModel::data(const QModelIndex &idx, int role) const
+{
+    if (!idx.isValid() || idx.row() >= m_data.size())
+        return QVariant();
+
+    const QLocale& loc = m_data.at(idx.row());
+
+    switch (role)
+    {
+    case Qt::DisplayRole:
+    {
+        //NOTE: Do not show "American English" for default locale (row 0)
+        if(idx.row() > 0)
+            return loc.nativeLanguageName();
+        Q_FALLTHROUGH();
+    }
+    case Qt::ToolTipRole:
+        return QLocale::languageToString(loc.language()); //Return english name in tooltip
+    }
+
+    return QVariant();
+}
+
+void LanguageModel::loadAvailableLanguages()
+{
+    beginResetModel();
+    m_data = utils::language::getAvailableTranslations();
+    endResetModel();
+}
+
+QLocale LanguageModel::getLocaleAt(int idx)
+{
+    return m_data.value(idx, QLocale::c());
+}
+
+int LanguageModel::findMatchingRow(const QLocale &loc)
+{
+    int exactMatchIdx = -1;
+    int partialMatchIdx = -1;
+    for(int i = 0; i < m_data.size(); i++)
+    {
+        const QLocale& item = m_data.at(i);
+        if(item.language() == loc.language())
+        {
+            partialMatchIdx = i;
+
+            if(item.country() == loc.country())
+            {
+                exactMatchIdx = i;
+                break;
+            }
+        }
+    }
+
+    if(exactMatchIdx != -1)
+        return exactMatchIdx;
+
+    if(partialMatchIdx != -1)
+        return partialMatchIdx;
+
+    return 0;
+}

--- a/src/settings/languagemodel.h
+++ b/src/settings/languagemodel.h
@@ -1,0 +1,33 @@
+#ifndef LANGUAGEMODEL_H
+#define LANGUAGEMODEL_H
+
+#include <QAbstractListModel>
+
+#include <QLocale>
+#include <QVector>
+
+class LanguageModel : public QAbstractListModel
+{
+    Q_OBJECT
+public:
+    explicit LanguageModel(QObject *parent = nullptr);
+
+    // Header:
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+    // Basic functionality:
+    int rowCount(const QModelIndex &p = QModelIndex()) const override;
+
+    QVariant data(const QModelIndex &idx, int role = Qt::DisplayRole) const override;
+
+    void loadAvailableLanguages();
+
+    QLocale getLocaleAt(int idx);
+
+    int findMatchingRow(const QLocale& loc);
+
+private:
+    QVector<QLocale> m_data;
+};
+
+#endif // LANGUAGEMODEL_H

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -125,12 +125,15 @@ void SettingsDialog::setupLanguageBox()
     ui->sheetLanguageCombo->setModel(languageModel);
 }
 
-void SettingsDialog::setSheetLanguage(const QLocale &appLoc, const QLocale &sheetLoc)
+void SettingsDialog::setSheetLanguage(const QLocale &sheetLoc)
 {
     QTranslator *sheetTranslator = nullptr;
-    if(appLoc != sheetLoc || sheetLoc == QLocale(QLocale::English))
+    if(Session->getAppLanguage() != sheetLoc || sheetLoc == QLocale(QLocale::English))
     {
-        //Sheet Export needs a different (non-default) translation
+        //Sheet Language is different from original (currently loaded) App Language
+        //And it's not default (English with default country) which is embedded in executable
+
+        //Sheet Export needs a different translation
         if(Session->getSheetExportLocale() == sheetLoc)
         {
             //Try to re-use old one
@@ -243,12 +246,13 @@ void SettingsDialog::saveSettings()
     auto &settings = AppSettings;
 
     //General
-    QVariant v = ui->appLanguageCombo->currentData();
-    QLocale loc = v.toLocale();
-    settings.setLanguage(loc);
+    int idx = ui->appLanguageCombo->currentIndex();
+    QLocale appLoc = languageModel->getLocaleAt(idx);
+    settings.setLanguage(appLoc);
 
-    v = ui->sheetLanguageCombo->currentData();
-
+    idx = ui->sheetLanguageCombo->currentIndex();
+    QLocale sheetLoc = languageModel->getLocaleAt(idx);
+    setSheetLanguage(sheetLoc);
 
     //Job Graph
     settings.setHourOffset(ui->hourOffsetSpin->value());

--- a/src/settings/settingsdialog.cpp
+++ b/src/settings/settingsdialog.cpp
@@ -128,10 +128,10 @@ void SettingsDialog::setupLanguageBox()
 void SettingsDialog::setSheetLanguage(const QLocale &sheetLoc)
 {
     QTranslator *sheetTranslator = nullptr;
-    if(Session->getAppLanguage() != sheetLoc || sheetLoc == QLocale(QLocale::English))
+    if(Session->getAppLanguage() != sheetLoc && sheetLoc != MeetingSession::embeddedLocale)
     {
         //Sheet Language is different from original (currently loaded) App Language
-        //And it's not default (English with default country) which is embedded in executable
+        //And it's not default language embedded in executable
 
         //Sheet Export needs a different translation
         if(Session->getSheetExportLocale() == sheetLoc)

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -42,7 +42,7 @@ private slots:
 
 private:
     void setupLanguageBox();
-    void setSheetLanguage(const QLocale& appLoc, const QLocale& sheetLoc);
+    void setSheetLanguage(const QLocale& sheetLoc);
 
 private:
     Ui::SettingsDialog *ui;

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -13,6 +13,7 @@ class SettingsDialog;
 
 class QSpinBox;
 class ColorView;
+class LanguageModel;
 
 class SettingsDialog : public QDialog
 {
@@ -28,6 +29,9 @@ public slots:
     void restoreDefaults();
 
     void onRestore();
+
+    void resetSheetLanguage();
+
 protected:
     void closeEvent(QCloseEvent *e);
 
@@ -38,10 +42,11 @@ private slots:
 
 private:
     void setupLanguageBox();
-    int findLocaleIdx(const QLocale& loc);
+    void setSheetLanguage(const QLocale& appLoc, const QLocale& sheetLoc);
 
 private:
     Ui::SettingsDialog *ui;
+    LanguageModel *languageModel;
 
     bool updateJobsColors;
     bool updateJobGraphOptions;

--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -38,6 +38,7 @@ private slots:
 
 private:
     void setupLanguageBox();
+    int findLocaleIdx(const QLocale& loc);
 
 private:
     Ui::SettingsDialog *ui;

--- a/src/settings/settingsdialog.ui
+++ b/src/settings/settingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>500</height>
+    <height>494</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -67,51 +67,137 @@
       <attribute name="title">
        <string>General</string>
       </attribute>
-      <layout class="QFormLayout" name="formLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label">
-         <property name="minimumSize">
-          <size>
-           <width>100</width>
-           <height>0</height>
-          </size>
+      <layout class="QFormLayout" name="formLayout_11">
+       <item row="0" column="0" colspan="2">
+        <widget class="QGroupBox" name="appLanguageBox">
+         <property name="title">
+          <string>Application Language:</string>
          </property>
-         <property name="text">
-          <string>Language</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="languageCombo">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>23</height>
-          </size>
-         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Language:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="appLanguageCombo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>23</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QLabel" name="label_22">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Application Language changes will be applied next time you start the application!</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item row="1" column="0" colspan="2">
-        <widget class="QLabel" name="label_22">
-         <property name="font">
-          <font>
-           <pointsize>10</pointsize>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
+        <widget class="QGroupBox" name="sheetExportLanguageBox">
+         <property name="title">
+          <string>Sheet Export Language:</string>
          </property>
-         <property name="text">
-          <string>Language changes will be applied next time you start the application</string>
-         </property>
+         <layout class="QFormLayout" name="formLayout_10">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Language:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="sheetLanguageCombo">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>23</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QLabel" name="label_23">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>This is the language for exported sheets. It will be reset at every launch to same language of application.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="resetSheetLangBut">
+            <property name="text">
+             <string>Reset to Application</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="2" column="0">
         <widget class="QPushButton" name="restoreBut">
          <property name="maximumSize">
           <size>
@@ -123,6 +209,19 @@
           <string>Restore Default Settings</string>
          </property>
         </widget>
+       </item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/shifts/shiftgraph/shiftgrapheditor.cpp
+++ b/src/shifts/shiftgraph/shiftgrapheditor.cpp
@@ -17,6 +17,7 @@
 #include <QFileDialog>
 #include <QStandardPaths>
 #include "utils/file_format_names.h"
+#include "utils/openfileinfolder.h"
 
 #include <QDebug>
 
@@ -88,6 +89,8 @@ void ShiftGraphEditor::onSaveGraph()
     {
         exportSVG(fileName);
     }
+
+    utils::OpenFileInFolderDlg::askUser(tr("Shift Graph Saved"), fileName, this);
 }
 
 void ShiftGraphEditor::onPrintGraph()

--- a/src/shifts/shiftmanager.cpp
+++ b/src/shifts/shiftmanager.cpp
@@ -20,6 +20,7 @@
 #include <QActionGroup>
 
 #include "odt_export/shiftsheetexport.h"
+#include "utils/openfileinfolder.h"
 
 #include "utils/file_format_names.h"
 
@@ -206,4 +207,6 @@ void ShiftManager::onSaveSheet()
     ShiftSheetExport w(Session->m_Db, shiftId);
     w.write();
     w.save(fileName);
+
+    utils::OpenFileInFolderDlg::askUser(tr("Shift Sheet Saved"), fileName, this);
 }

--- a/src/stations/manager/stationjobview.cpp
+++ b/src/stations/manager/stationjobview.cpp
@@ -13,6 +13,7 @@
 #include <QMenu>
 
 #include "odt_export/stationsheetexport.h"
+#include "utils/openfileinfolder.h"
 
 #include "stationplanmodel.h"
 
@@ -128,4 +129,6 @@ void StationJobView::onSaveSheet()
     StationSheetExport sheet(m_stationId);
     sheet.write();
     sheet.save(fileName);
+
+    utils::OpenFileInFolderDlg::askUser(tr("Station Sheet Saved"), fileName, this);
 }

--- a/src/translations/mrtp_de.ts
+++ b/src/translations/mrtp_de.ts
@@ -905,84 +905,89 @@ NOTE: this doesn&apos;t affect stop times but you will lose manual adjustments t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="222"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="223"/>
         <source>Toggle transit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="223"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="224"/>
         <source>Set transit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="224"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="225"/>
         <source>Unset transit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="229"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="230"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="226"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="227"/>
         <source>Edit stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="365"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="366"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="366"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="367"/>
         <source>You must register at least 2 stops.
 Do you want to delete this job?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="481"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="482"/>
         <source>Save?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="482"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="483"/>
         <source>Do you want to save changes to job %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="169"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="170"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="170"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="171"/>
         <source>Job number &lt;b&gt;%1&lt;/b&gt; is already exists.&lt;br&gt;Please choose a different number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="228"/>
         <source>Station SVG Plan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="574"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="575"/>
         <source>Empty Job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="575"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="576"/>
         <source>Before setting a shift you should add stops to this job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="620"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="621"/>
         <source>Save Job Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="624"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="625"/>
         <source>job%1_sheet.odt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="643"/>
+        <source>Job Sheet Saved</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2005,46 +2010,42 @@ Extension: (*.ods)</source>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="643"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="362"/>
         <source>Arrival</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="644"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="363"/>
         <source>Departure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="645"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="248"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="365"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="377"/>
         <source>Platf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="646"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="246"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="368"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="380"/>
         <source>Rollingstock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="647"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="369"/>
         <source>Crossings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="648"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="370"/>
         <source>Passings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="649"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="371"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="383"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2105,33 +2106,63 @@ Extension: (*.ods)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="311"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="327"/>
         <source>Station: %1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="315"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="322"/>
         <source> (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="364"/>
-        <source>Job N</source>
+        <location filename="../odt_export/common/stationwriter.cpp" line="374"/>
+        <source>Arr.</source>
+        <comment>Arrival column</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="366"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="375"/>
+        <source>Dep.</source>
+        <comment>Departure column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="376"/>
+        <source>Job Nr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="378"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="367"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="379"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="584"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="381"/>
+        <source>Cross</source>
+        <comment>Crossings column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="382"/>
+        <source>Passings</source>
+        <comment>Passings column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="599"/>
         <source>Transit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="610"/>
+        <source>START</source>
+        <comment>Do not translate this text</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2140,12 +2171,12 @@ Extension: (*.ods)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="420"/>
+        <location filename="../odt_export/shiftsheetexport.cpp" line="422"/>
         <source>From %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="479"/>
+        <location filename="../odt_export/shiftsheetexport.cpp" line="481"/>
         <source>SHIFT %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3786,38 +3817,43 @@ Extension: (*.ttt)</source>
 <context>
     <name>SessionStartEndRSViewer</name>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="31"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="32"/>
         <source>Show Session Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="32"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="33"/>
         <source>Show Session End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="36"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="37"/>
         <source>Order By Station</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="37"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="38"/>
         <source>Order By Owner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="43"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="44"/>
         <source>Export Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="60"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="61"/>
         <source>Rollingstock Summary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="81"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="82"/>
         <source>Expoert RS session plan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="102"/>
+        <source>Session RS Plan Saved</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4161,33 +4197,38 @@ Extension: (*.ttt)</source>
 <context>
     <name>ShiftGraphEditor</name>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="36"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="37"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="37"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="38"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="38"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="39"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="39"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="40"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="55"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="56"/>
         <source>Shift Graph Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="65"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="66"/>
         <source>Save Shift Graph</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="93"/>
+        <source>Shift Graph Saved</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4231,89 +4272,94 @@ Extension: (*.ttt)</source>
 <context>
     <name>ShiftManager</name>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="52"/>
+        <location filename="../shifts/shiftmanager.cpp" line="53"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="53"/>
+        <location filename="../shifts/shiftmanager.cpp" line="54"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="55"/>
+        <location filename="../shifts/shiftmanager.cpp" line="56"/>
         <source>View Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="56"/>
+        <location filename="../shifts/shiftmanager.cpp" line="57"/>
         <source>Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="58"/>
+        <location filename="../shifts/shiftmanager.cpp" line="59"/>
         <source>Graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="72"/>
+        <location filename="../shifts/shiftmanager.cpp" line="73"/>
         <source>Create new Job Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="73"/>
+        <location filename="../shifts/shiftmanager.cpp" line="74"/>
         <source>Remove selected Job Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="74"/>
+        <location filename="../shifts/shiftmanager.cpp" line="75"/>
         <source>Show selected Job Shift plan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="75"/>
+        <location filename="../shifts/shiftmanager.cpp" line="76"/>
         <source>Save selected Job Shift plan on file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="76"/>
+        <location filename="../shifts/shiftmanager.cpp" line="77"/>
         <source>Show Job Shift graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="78"/>
+        <location filename="../shifts/shiftmanager.cpp" line="79"/>
         <source>Shift Manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="117"/>
+        <location filename="../shifts/shiftmanager.cpp" line="118"/>
         <source>Error Adding Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="118"/>
+        <location filename="../shifts/shiftmanager.cpp" line="119"/>
         <source>An error occurred while adding a new shift:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="138"/>
+        <location filename="../shifts/shiftmanager.cpp" line="139"/>
         <source>Remove Shift?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="139"/>
+        <location filename="../shifts/shiftmanager.cpp" line="140"/>
         <source>Are you sure you want to remove Job Shift &lt;b&gt;%1&lt;/b&gt;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="189"/>
+        <location filename="../shifts/shiftmanager.cpp" line="190"/>
         <source>Save Shift Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="193"/>
+        <location filename="../shifts/shiftmanager.cpp" line="194"/>
         <source>shift_%1.odt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shifts/shiftmanager.cpp" line="211"/>
+        <source>Shift Sheet Saved</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4838,23 +4884,28 @@ It can also be both (Bidirectional) but cannot be neither.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="90"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="91"/>
         <source>Show in Job Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="91"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="92"/>
         <source>Show job in graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="110"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="111"/>
         <source>Save Station Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="114"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="115"/>
         <source>%1_station.odt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../stations/manager/stationjobview.cpp" line="133"/>
+        <source>Station Sheet Saved</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5530,6 +5581,24 @@ Please choose a new out gate or out track, this might change next segment.</sour
     <message>
         <location filename="../viewmanager/viewmanager.cpp" line="648"/>
         <source>Are you sure you want to remove Job &lt;b&gt;%1&lt;/b&gt;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>utils::OpenFileInFolderDlg</name>
+    <message>
+        <location filename="../utils/openfileinfolder.cpp" line="54"/>
+        <source>Open In App</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/openfileinfolder.cpp" line="55"/>
+        <source>Show Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../utils/openfileinfolder.cpp" line="84"/>
+        <source>Do you want to open file?&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/translations/mrtp_de.ts
+++ b/src/translations/mrtp_de.ts
@@ -5587,17 +5587,17 @@ Please choose a new out gate or out track, this might change next segment.</sour
 <context>
     <name>utils::OpenFileInFolderDlg</name>
     <message>
-        <location filename="../utils/openfileinfolder.cpp" line="54"/>
+        <location filename="../utils/openfileinfolder.cpp" line="62"/>
         <source>Open In App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../utils/openfileinfolder.cpp" line="55"/>
+        <location filename="../utils/openfileinfolder.cpp" line="63"/>
         <source>Show Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../utils/openfileinfolder.cpp" line="84"/>
+        <location filename="../utils/openfileinfolder.cpp" line="110"/>
         <source>Do you want to open file?&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/mrtp_de.ts
+++ b/src/translations/mrtp_de.ts
@@ -1075,6 +1075,14 @@ Do you want to delete this job?</source>
     </message>
 </context>
 <context>
+    <name>LanguageModel</name>
+    <message>
+        <location filename="../settings/languagemodel.cpp" line="15"/>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LineGraphToolbar</name>
     <message>
         <location filename="../graph/view/linegraphtoolbar.cpp" line="36"/>
@@ -1976,216 +1984,6 @@ Extension: (*.ods)</source>
 <context>
     <name>Odt</name>
     <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="40"/>
-        <source>From:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="42"/>
-        <source>Departure:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="51"/>
-        <source>To:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="53"/>
-        <source>Arrival:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="62"/>
-        <source>Axes:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="642"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="250"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="338"/>
-        <source>Station</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="643"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <source>Arrival</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="644"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <source>Departure</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="645"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="248"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="377"/>
-        <source>Platf</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="646"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="246"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="380"/>
-        <source>Rollingstock</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="647"/>
-        <source>Crossings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="648"/>
-        <source>Passings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="649"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="383"/>
-        <source>Notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtdocument.cpp" line="347"/>
-        <source>Meeting in %1 from %2 to %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtdocument.cpp" line="354"/>
-        <source>Meeting in %1 on %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtdocument.cpp" line="405"/>
-        <source>Meeting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtutils.cpp" line="299"/>
-        <source>Page </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtutils.h" line="69"/>
-        <source>Cp:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtutils.h" line="70"/>
-        <source>Unc:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="247"/>
-        <source>Job</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="250"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="338"/>
-        <source>Owner</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="337"/>
-        <source>Rollingstock by %1 at %2 of session</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="339"/>
-        <source>start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="339"/>
-        <source>end</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="327"/>
-        <source>Station: %1%2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="322"/>
-        <source> (%1)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="374"/>
-        <source>Arr.</source>
-        <comment>Arrival column</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="375"/>
-        <source>Dep.</source>
-        <comment>Departure column</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="376"/>
-        <source>Job Nr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="378"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="379"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="381"/>
-        <source>Cross</source>
-        <comment>Crossings column</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="382"/>
-        <source>Passings</source>
-        <comment>Passings column</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="599"/>
-        <source>Transit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="610"/>
-        <source>START</source>
-        <comment>Do not translate this text</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="104"/>
-        <source>Shift %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="422"/>
-        <source>From %1 to %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="481"/>
-        <source>SHIFT %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/stationsheetexport.cpp" line="76"/>
-        <source>%1 station</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../stations/manager/stations/model/stationsvghelper.cpp" line="46"/>
         <location filename="../stations/manager/stations/model/stationsvghelper.cpp" line="93"/>
         <source>Null device</source>
@@ -2199,6 +1997,228 @@ Extension: (*.ods)</source>
     <message>
         <location filename="../stations/manager/stations/model/stationsvghelper.cpp" line="100"/>
         <source>Cannot open source: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="73"/>
+        <source>Page </source>
+        <comment>Header page, leave space at end, page number will be added</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="76"/>
+        <source>Meeting</source>
+        <comment>Document keywords</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="77"/>
+        <source>Meeting in %1 from %2 to %3</source>
+        <comment>Document description, where, from date, to date</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="78"/>
+        <source>Meeting in %1 on %2</source>
+        <comment>Document description, where, when</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="79"/>
+        <source>From %1 to %2</source>
+        <comment>Shift cover, meeting from date, to date</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="82"/>
+        <source>Cp:</source>
+        <comment>Job stop coupled RS</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="83"/>
+        <source>Unc:</source>
+        <comment>Job stop uncoupled RS</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="84"/>
+        <source>Owner</source>
+        <comment>Rollingstock Owner</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="86"/>
+        <source>Rollingstock by %1 at %2 of session</source>
+        <comment>Rollingstock Session title, 1 is Owner/Station and 2 is start/end</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="88"/>
+        <source>start</source>
+        <comment>Rollingstock Session start</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="89"/>
+        <source>end</source>
+        <comment>Rollingstock Session end</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="92"/>
+        <source>From:</source>
+        <comment>Job summary</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="93"/>
+        <source>To:</source>
+        <comment>Job summary</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="94"/>
+        <source>Departure:</source>
+        <comment>Job summary</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="95"/>
+        <source>Arrival:</source>
+        <comment>Job summary</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="96"/>
+        <source>Axes:</source>
+        <comment>Job summary</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="99"/>
+        <source>Station</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="100"/>
+        <source>Station: %1</source>
+        <comment>Station title in station sheet</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="101"/>
+        <source>%1 station</source>
+        <comment>Station sheet title in document metadata</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="102"/>
+        <source>Rollingstock</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="103"/>
+        <source>Job Nr</source>
+        <comment>Job column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="105"/>
+        <source>Arrival</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="106"/>
+        <source>Departure</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="107"/>
+        <source>Arr.</source>
+        <comment>Arrival abbreviated</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="108"/>
+        <source>Dep.</source>
+        <comment>Departure abbreviated</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="110"/>
+        <source>From</source>
+        <comment>Station stop table, From previous station column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="111"/>
+        <source>To</source>
+        <comment>Station stop table, To next station column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="113"/>
+        <source>Platf</source>
+        <comment>Job stop table, platform abbreviated</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="114"/>
+        <source>Transit</source>
+        <comment>Job stop table, notes column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="115"/>
+        <source>START</source>
+        <comment>Station stop table, notes column for first job stop, keep in English it&apos;s the same for every sheet</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="119"/>
+        <source>Crossings</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="120"/>
+        <source>Passings</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="121"/>
+        <source>Cross</source>
+        <comment>Job stop crossings abbreviated column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="122"/>
+        <source>Passes</source>
+        <comment>Job stop passings abbreviated column</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="123"/>
+        <source>Notes</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="126"/>
+        <source>SHIFT %1</source>
+        <comment>Shift title in shift sheet cover</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="127"/>
+        <source>Shift %1</source>
+        <comment>Shift sheet document title for metadata</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3861,8 +3881,8 @@ Extension: (*.ttt)</source>
     <name>SettingsDialog</name>
     <message>
         <location filename="../settings/settingsdialog.ui" line="32"/>
-        <location filename="../settings/settingsdialog.cpp" line="338"/>
-        <location filename="../settings/settingsdialog.cpp" line="356"/>
+        <location filename="../settings/settingsdialog.cpp" line="366"/>
+        <location filename="../settings/settingsdialog.cpp" line="384"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3872,293 +3892,314 @@ Extension: (*.ttt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="80"/>
-        <source>Language</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settings/settingsdialog.ui" line="110"/>
-        <source>Language changes will be applied next time you start the application</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settings/settingsdialog.ui" line="123"/>
+        <location filename="../settings/settingsdialog.ui" line="209"/>
         <source>Restore Default Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="131"/>
+        <location filename="../settings/settingsdialog.ui" line="230"/>
         <source>Job Graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="173"/>
-        <location filename="../settings/settingsdialog.ui" line="545"/>
+        <location filename="../settings/settingsdialog.ui" line="272"/>
+        <location filename="../settings/settingsdialog.ui" line="644"/>
         <source>Offsets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="179"/>
+        <location filename="../settings/settingsdialog.ui" line="278"/>
         <source>Stations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="193"/>
-        <location filename="../settings/settingsdialog.ui" line="551"/>
+        <location filename="../settings/settingsdialog.ui" line="292"/>
+        <location filename="../settings/settingsdialog.ui" line="650"/>
         <source>Hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="207"/>
-        <location filename="../settings/settingsdialog.ui" line="287"/>
+        <location filename="../settings/settingsdialog.ui" line="306"/>
+        <location filename="../settings/settingsdialog.ui" line="386"/>
         <source>Platforms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="221"/>
-        <location filename="../settings/settingsdialog.ui" line="565"/>
+        <location filename="../settings/settingsdialog.ui" line="320"/>
+        <location filename="../settings/settingsdialog.ui" line="664"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="235"/>
-        <location filename="../settings/settingsdialog.ui" line="572"/>
+        <location filename="../settings/settingsdialog.ui" line="334"/>
+        <location filename="../settings/settingsdialog.ui" line="671"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="258"/>
+        <location filename="../settings/settingsdialog.ui" line="357"/>
         <source>Line Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="267"/>
-        <location filename="../settings/settingsdialog.ui" line="585"/>
+        <location filename="../settings/settingsdialog.ui" line="366"/>
+        <location filename="../settings/settingsdialog.ui" line="684"/>
         <source>Job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="277"/>
+        <location filename="../settings/settingsdialog.ui" line="376"/>
         <source>Hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="300"/>
+        <location filename="../settings/settingsdialog.ui" line="399"/>
         <source>Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="306"/>
+        <location filename="../settings/settingsdialog.ui" line="405"/>
         <source>Hour Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="329"/>
+        <location filename="../settings/settingsdialog.ui" line="428"/>
         <source>Hour Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="358"/>
+        <location filename="../settings/settingsdialog.ui" line="457"/>
         <source>Main Platform</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="381"/>
+        <location filename="../settings/settingsdialog.ui" line="480"/>
         <source>Depot Platform</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="404"/>
+        <location filename="../settings/settingsdialog.ui" line="503"/>
         <source>Station Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="430"/>
+        <location filename="../settings/settingsdialog.ui" line="529"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="436"/>
+        <location filename="../settings/settingsdialog.ui" line="535"/>
         <source>Follow Job selection on Graph change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="443"/>
+        <location filename="../settings/settingsdialog.ui" line="542"/>
         <source>Sync Job selection on all graphs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="458"/>
+        <location filename="../settings/settingsdialog.ui" line="557"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="470"/>
+        <location filename="../settings/settingsdialog.ui" line="569"/>
         <source>Default Stop Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="486"/>
+        <location filename="../settings/settingsdialog.ui" line="585"/>
         <source>Job Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="495"/>
+        <location filename="../settings/settingsdialog.ui" line="594"/>
         <source>Auto insert transits between two stops.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="509"/>
+        <location filename="../settings/settingsdialog.ui" line="608"/>
         <source>Auto uncouple all rollingstock items at last stop.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="502"/>
+        <location filename="../settings/settingsdialog.ui" line="601"/>
         <source>Auto move uncoupled rollingstock pieces from last stop when adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="533"/>
+        <location filename="../settings/settingsdialog.ui" line="74"/>
+        <source>Application Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="86"/>
+        <location filename="../settings/settingsdialog.ui" line="147"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="122"/>
+        <source>Application Language changes will be applied next time you start the application!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="135"/>
+        <source>Sheet Export Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="183"/>
+        <source>This is the language for exported sheets. It will be reset at every launch to same language of application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="193"/>
+        <source>Reset to Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="632"/>
         <source>Shift Graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="595"/>
+        <location filename="../settings/settingsdialog.ui" line="694"/>
         <source>Job Box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="605"/>
+        <location filename="../settings/settingsdialog.ui" line="704"/>
         <source>Stations Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="615"/>
+        <location filename="../settings/settingsdialog.ui" line="714"/>
         <source>Hide Same Stations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="642"/>
+        <location filename="../settings/settingsdialog.ui" line="741"/>
         <source>Rollingstock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="654"/>
+        <location filename="../settings/settingsdialog.ui" line="753"/>
         <source>Merge models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="663"/>
+        <location filename="../settings/settingsdialog.ui" line="762"/>
         <source>Remove source merged model by default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="679"/>
+        <location filename="../settings/settingsdialog.ui" line="778"/>
         <source>Merge owners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="688"/>
+        <location filename="../settings/settingsdialog.ui" line="787"/>
         <source>Remove sourcemerged owner by default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="698"/>
+        <location filename="../settings/settingsdialog.ui" line="797"/>
         <source>Open Document Spreadsheet Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="704"/>
+        <location filename="../settings/settingsdialog.ui" line="803"/>
         <source>First non-empty row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="721"/>
+        <location filename="../settings/settingsdialog.ui" line="820"/>
         <source>Number column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="728"/>
+        <location filename="../settings/settingsdialog.ui" line="827"/>
         <source>Model column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="772"/>
+        <location filename="../settings/settingsdialog.ui" line="871"/>
         <source>Sheet Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="778"/>
+        <location filename="../settings/settingsdialog.ui" line="877"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="784"/>
+        <location filename="../settings/settingsdialog.ui" line="883"/>
         <source>Header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="791"/>
+        <location filename="../settings/settingsdialog.ui" line="890"/>
         <source>Footer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="807"/>
+        <location filename="../settings/settingsdialog.ui" line="906"/>
         <source>Metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="813"/>
+        <location filename="../settings/settingsdialog.ui" line="912"/>
         <source>Store meeting location and dates in sheet metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="837"/>
+        <location filename="../settings/settingsdialog.ui" line="936"/>
         <source>Background Tasks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="843"/>
+        <location filename="../settings/settingsdialog.ui" line="942"/>
         <source>Rollingstock Error Checker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="849"/>
+        <location filename="../settings/settingsdialog.ui" line="948"/>
         <source>Check rollingstock when opening a file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="856"/>
+        <location filename="../settings/settingsdialog.ui" line="955"/>
         <source>Check rollingstock when a Job is edeited</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="30"/>
+        <location filename="../settings/settingsdialog.cpp" line="32"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="79"/>
+        <location filename="../settings/settingsdialog.cpp" line="81"/>
         <source>Job Colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="84"/>
+        <location filename="../settings/settingsdialog.cpp" line="86"/>
         <source>Non Passenger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="96"/>
+        <location filename="../settings/settingsdialog.cpp" line="98"/>
         <source>Passenger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="339"/>
+        <location filename="../settings/settingsdialog.cpp" line="367"/>
         <source>Do you want to save settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="357"/>
+        <location filename="../settings/settingsdialog.cpp" line="385"/>
         <source>Do you want to restore default settings?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/translations/mrtp_it.ts
+++ b/src/translations/mrtp_it.ts
@@ -2120,10 +2120,6 @@ Estensione: (*.ods)</translation>
         <translation></translation>
     </message>
     <message>
-        <source>Job N</source>
-        <translation type="vanished">Treno N</translation>
-    </message>
-    <message>
         <location filename="../odt_export/common/stationwriter.cpp" line="378"/>
         <source>From</source>
         <translation>Da</translation>
@@ -5651,17 +5647,17 @@ Per favore scegli un altro Binario o cambia la Tratta successiva.</translation>
 <context>
     <name>utils::OpenFileInFolderDlg</name>
     <message>
-        <location filename="../utils/openfileinfolder.cpp" line="54"/>
+        <location filename="../utils/openfileinfolder.cpp" line="62"/>
         <source>Open In App</source>
         <translation>Apri in App</translation>
     </message>
     <message>
-        <location filename="../utils/openfileinfolder.cpp" line="55"/>
+        <location filename="../utils/openfileinfolder.cpp" line="63"/>
         <source>Show Folder</source>
         <translation>Mostra Cartella</translation>
     </message>
     <message>
-        <location filename="../utils/openfileinfolder.cpp" line="84"/>
+        <location filename="../utils/openfileinfolder.cpp" line="110"/>
         <source>Do you want to open file?&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</source>
         <translation>Vuoi aprire il file?&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</translation>
     </message>

--- a/src/translations/mrtp_it.ts
+++ b/src/translations/mrtp_it.ts
@@ -1083,6 +1083,14 @@ Vuoi eliminare questo servizio?</translation>
     </message>
 </context>
 <context>
+    <name>LanguageModel</name>
+    <message>
+        <location filename="../settings/languagemodel.cpp" line="15"/>
+        <source>Language</source>
+        <translation type="unfinished">Lingua</translation>
+    </message>
+</context>
+<context>
     <name>LineGraphToolbar</name>
     <message>
         <location filename="../graph/view/linegraphtoolbar.cpp" line="36"/>
@@ -1996,216 +2004,6 @@ Estensione: (*.ods)</translation>
 <context>
     <name>Odt</name>
     <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="40"/>
-        <source>From:</source>
-        <translation>Da:</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="42"/>
-        <source>Departure:</source>
-        <translation>Partenza:</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="51"/>
-        <source>To:</source>
-        <translation>Per:</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="53"/>
-        <source>Arrival:</source>
-        <translation>Arrivo:</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="62"/>
-        <source>Axes:</source>
-        <translation>Assi:</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="642"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="250"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="338"/>
-        <source>Station</source>
-        <translation>Stazione</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="643"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <source>Arrival</source>
-        <translation>Arrivo</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="644"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <source>Departure</source>
-        <translation>Partenza</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="645"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="248"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="377"/>
-        <source>Platf</source>
-        <translation>Bin</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="646"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="246"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="380"/>
-        <source>Rollingstock</source>
-        <translation>Rotabili</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="647"/>
-        <source>Crossings</source>
-        <translation>Incroci</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="648"/>
-        <source>Passings</source>
-        <translation>Precedenze</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/jobwriter.cpp" line="649"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="383"/>
-        <source>Notes</source>
-        <translation>Note</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="599"/>
-        <source>Transit</source>
-        <translation>Transito</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="327"/>
-        <source>Station: %1%2</source>
-        <translation>Stazione %1%2</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="322"/>
-        <source> (%1)</source>
-        <translation> (%1)</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="374"/>
-        <source>Arr.</source>
-        <comment>Arrival column</comment>
-        <translation>Arr.</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="375"/>
-        <source>Dep.</source>
-        <comment>Departure column</comment>
-        <translation>Part.</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="376"/>
-        <source>Job Nr</source>
-        <translation>Treno N.</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="381"/>
-        <source>Cross</source>
-        <comment>Crossings column</comment>
-        <translation>Incrocia</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="382"/>
-        <source>Passings</source>
-        <comment>Passings column</comment>
-        <translation>Prec.</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="610"/>
-        <source>START</source>
-        <comment>Do not translate this text</comment>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="378"/>
-        <source>From</source>
-        <translation>Da</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="379"/>
-        <source>To</source>
-        <translation>Per</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="104"/>
-        <source>Shift %1</source>
-        <translation>Turno %1</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtutils.cpp" line="299"/>
-        <source>Page </source>
-        <translation>Pagina </translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="247"/>
-        <source>Job</source>
-        <translation>Servizio</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="250"/>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="338"/>
-        <source>Owner</source>
-        <translation>Proprietario</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="337"/>
-        <source>Rollingstock by %1 at %2 of session</source>
-        <translation>Rotabili per %1 a %2 sessione</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="339"/>
-        <source>start</source>
-        <translation>inizio</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/sessionrswriter.cpp" line="339"/>
-        <source>end</source>
-        <translation>fine</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="422"/>
-        <source>From %1 to %2</source>
-        <translation>Dal %1 al %2</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="481"/>
-        <source>SHIFT %1</source>
-        <translation>TURNO %1</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtdocument.cpp" line="347"/>
-        <source>Meeting in %1 from %2 to %3</source>
-        <translation>Meeting a %1 dal %2 al %3</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtdocument.cpp" line="354"/>
-        <source>Meeting in %1 on %2</source>
-        <translation>Meeting a %1 il %2</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtdocument.cpp" line="405"/>
-        <source>Meeting</source>
-        <translation>Sessione</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/stationsheetexport.cpp" line="76"/>
-        <source>%1 station</source>
-        <translation>Stazione di %1</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtutils.h" line="69"/>
-        <source>Cp:</source>
-        <translation>Ag:</translation>
-    </message>
-    <message>
-        <location filename="../odt_export/common/odtutils.h" line="70"/>
-        <source>Unc:</source>
-        <translation>Sg:</translation>
-    </message>
-    <message>
         <location filename="../stations/manager/stations/model/stationsvghelper.cpp" line="46"/>
         <location filename="../stations/manager/stations/model/stationsvghelper.cpp" line="93"/>
         <source>Null device</source>
@@ -2220,6 +2018,228 @@ Estensione: (*.ods)</translation>
         <location filename="../stations/manager/stations/model/stationsvghelper.cpp" line="100"/>
         <source>Cannot open source: %1</source>
         <translation>Impossibile aprire sorgente: %1</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="73"/>
+        <source>Page </source>
+        <comment>Header page, leave space at end, page number will be added</comment>
+        <translation>Pagina </translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="76"/>
+        <source>Meeting</source>
+        <comment>Document keywords</comment>
+        <translation>Sessione</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="77"/>
+        <source>Meeting in %1 from %2 to %3</source>
+        <comment>Document description, where, from date, to date</comment>
+        <translation>Meeting a %1 dal %2 al %3</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="78"/>
+        <source>Meeting in %1 on %2</source>
+        <comment>Document description, where, when</comment>
+        <translation>Meeting a %1 il %2</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="79"/>
+        <source>From %1 to %2</source>
+        <comment>Shift cover, meeting from date, to date</comment>
+        <translation>Dal %1 al %2</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="82"/>
+        <source>Cp:</source>
+        <comment>Job stop coupled RS</comment>
+        <translation>Ag:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="83"/>
+        <source>Unc:</source>
+        <comment>Job stop uncoupled RS</comment>
+        <translation>Sg:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="84"/>
+        <source>Owner</source>
+        <comment>Rollingstock Owner</comment>
+        <translation>Proprietario</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="86"/>
+        <source>Rollingstock by %1 at %2 of session</source>
+        <comment>Rollingstock Session title, 1 is Owner/Station and 2 is start/end</comment>
+        <translation>Rotabili per %1 a %2 sessione</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="88"/>
+        <source>start</source>
+        <comment>Rollingstock Session start</comment>
+        <translation>inizio</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="89"/>
+        <source>end</source>
+        <comment>Rollingstock Session end</comment>
+        <translation>fine</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="92"/>
+        <source>From:</source>
+        <comment>Job summary</comment>
+        <translation>Da:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="93"/>
+        <source>To:</source>
+        <comment>Job summary</comment>
+        <translation>Per:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="94"/>
+        <source>Departure:</source>
+        <comment>Job summary</comment>
+        <translation>Partenza:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="95"/>
+        <source>Arrival:</source>
+        <comment>Job summary</comment>
+        <translation>Arrivo:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="96"/>
+        <source>Axes:</source>
+        <comment>Job summary</comment>
+        <translation>Assi:</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="99"/>
+        <source>Station</source>
+        <comment>Job stop table</comment>
+        <translation>Stazione</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="100"/>
+        <source>Station: %1</source>
+        <comment>Station title in station sheet</comment>
+        <translation>Stazione di: %1</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="101"/>
+        <source>%1 station</source>
+        <comment>Station sheet title in document metadata</comment>
+        <translation>stazione di %1</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="102"/>
+        <source>Rollingstock</source>
+        <comment>Job stop table</comment>
+        <translation>Rotabili</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="103"/>
+        <source>Job Nr</source>
+        <comment>Job column</comment>
+        <translation>Treno N.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="105"/>
+        <source>Arrival</source>
+        <comment>Job stop table</comment>
+        <translation>Arrivo</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="106"/>
+        <source>Departure</source>
+        <comment>Job stop table</comment>
+        <translation>Partenza</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="107"/>
+        <source>Arr.</source>
+        <comment>Arrival abbreviated</comment>
+        <translation>Arr.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="108"/>
+        <source>Dep.</source>
+        <comment>Departure abbreviated</comment>
+        <translation>Part.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="110"/>
+        <source>From</source>
+        <comment>Station stop table, From previous station column</comment>
+        <translation>Da</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="111"/>
+        <source>To</source>
+        <comment>Station stop table, To next station column</comment>
+        <translation>Per</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="113"/>
+        <source>Platf</source>
+        <comment>Job stop table, platform abbreviated</comment>
+        <translation>Bin</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="114"/>
+        <source>Transit</source>
+        <comment>Job stop table, notes column</comment>
+        <translation>Transito</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="115"/>
+        <source>START</source>
+        <comment>Station stop table, notes column for first job stop, keep in English it&apos;s the same for every sheet</comment>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="119"/>
+        <source>Crossings</source>
+        <comment>Job stop table</comment>
+        <translation>Incroci</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="120"/>
+        <source>Passings</source>
+        <comment>Job stop table</comment>
+        <translation>Precedenze</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="121"/>
+        <source>Cross</source>
+        <comment>Job stop crossings abbreviated column</comment>
+        <translation>Incrocia</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="122"/>
+        <source>Passes</source>
+        <comment>Job stop passings abbreviated column</comment>
+        <translation>Prec.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="123"/>
+        <source>Notes</source>
+        <comment>Job stop table</comment>
+        <translation>Note</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="126"/>
+        <source>SHIFT %1</source>
+        <comment>Shift title in shift sheet cover</comment>
+        <translation>TURNO %1</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="127"/>
+        <source>Shift %1</source>
+        <comment>Shift sheet document title for metadata</comment>
+        <translation>Turno %1</translation>
     </message>
 </context>
 <context>
@@ -3912,300 +3932,329 @@ Estensione: (*.ttt)</translation>
         <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="80"/>
         <source>Language</source>
-        <translation>Lingua</translation>
+        <translation type="vanished">Lingua</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="110"/>
         <source>Language changes will be applied next time you start the application</source>
-        <translation>Le impostazioni della lingua verranno applicate al prossimo avvio dell&apos;applicazione</translation>
+        <translation type="vanished">Le impostazioni della lingua verranno applicate al prossimo avvio dell&apos;applicazione</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="123"/>
+        <location filename="../settings/settingsdialog.ui" line="209"/>
         <source>Restore Default Settings</source>
         <translation>Ripristina Impostazioni Predefinite</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="131"/>
+        <location filename="../settings/settingsdialog.ui" line="230"/>
         <source>Job Graph</source>
         <translation>Grafico Servizi</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="173"/>
-        <location filename="../settings/settingsdialog.ui" line="545"/>
+        <location filename="../settings/settingsdialog.ui" line="272"/>
+        <location filename="../settings/settingsdialog.ui" line="644"/>
         <source>Offsets</source>
         <translation>Distanze</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="179"/>
+        <location filename="../settings/settingsdialog.ui" line="278"/>
         <source>Stations</source>
         <translation>Stazioni</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="193"/>
-        <location filename="../settings/settingsdialog.ui" line="551"/>
+        <location filename="../settings/settingsdialog.ui" line="292"/>
+        <location filename="../settings/settingsdialog.ui" line="650"/>
         <source>Hours</source>
         <translation>Ore</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="207"/>
-        <location filename="../settings/settingsdialog.ui" line="287"/>
+        <location filename="../settings/settingsdialog.ui" line="306"/>
+        <location filename="../settings/settingsdialog.ui" line="386"/>
         <source>Platforms</source>
         <translation>Binari</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="221"/>
-        <location filename="../settings/settingsdialog.ui" line="565"/>
+        <location filename="../settings/settingsdialog.ui" line="320"/>
+        <location filename="../settings/settingsdialog.ui" line="664"/>
         <source>Horizontal</source>
         <translation>Bordo Orizzontale</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="235"/>
-        <location filename="../settings/settingsdialog.ui" line="572"/>
+        <location filename="../settings/settingsdialog.ui" line="334"/>
+        <location filename="../settings/settingsdialog.ui" line="671"/>
         <source>Vertical</source>
         <translation>Bordo Verticale</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="258"/>
+        <location filename="../settings/settingsdialog.ui" line="357"/>
         <source>Line Width</source>
         <translation>Spessore Linea</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="267"/>
-        <location filename="../settings/settingsdialog.ui" line="585"/>
+        <location filename="../settings/settingsdialog.ui" line="366"/>
+        <location filename="../settings/settingsdialog.ui" line="684"/>
         <source>Job</source>
         <translation>Servizio</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="277"/>
+        <location filename="../settings/settingsdialog.ui" line="376"/>
         <source>Hour</source>
         <translation>Ora</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="300"/>
+        <location filename="../settings/settingsdialog.ui" line="399"/>
         <source>Colors</source>
         <translation>Colori</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="306"/>
+        <location filename="../settings/settingsdialog.ui" line="405"/>
         <source>Hour Line</source>
         <translation>Linea Ore</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="329"/>
+        <location filename="../settings/settingsdialog.ui" line="428"/>
         <source>Hour Text</source>
         <translation>Testo Ora</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="358"/>
+        <location filename="../settings/settingsdialog.ui" line="457"/>
         <source>Main Platform</source>
         <translation>Binario Principale</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="381"/>
+        <location filename="../settings/settingsdialog.ui" line="480"/>
         <source>Depot Platform</source>
         <translation>Binario Deposito</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="404"/>
+        <location filename="../settings/settingsdialog.ui" line="503"/>
         <source>Station Text</source>
         <translation>Testo Stazioni</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="430"/>
+        <location filename="../settings/settingsdialog.ui" line="529"/>
         <source>Selection</source>
         <translation>Selezione</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="436"/>
+        <location filename="../settings/settingsdialog.ui" line="535"/>
         <source>Follow Job selection on Graph change</source>
         <translation>Segui il Treno selezionato quando il Grafico cambia</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="443"/>
+        <location filename="../settings/settingsdialog.ui" line="542"/>
         <source>Sync Job selection on all graphs</source>
         <translation>Sincronizza selezione Trano su tutti i grafici</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="495"/>
+        <location filename="../settings/settingsdialog.ui" line="594"/>
         <source>Auto insert transits between two stops.</source>
         <translation>Inserisci automaticamente i transiti tra due fermate.</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="698"/>
+        <location filename="../settings/settingsdialog.ui" line="797"/>
         <source>Open Document Spreadsheet Import</source>
         <translation>Importa Foglio di calcolo OpenDocument</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="704"/>
+        <location filename="../settings/settingsdialog.ui" line="803"/>
         <source>First non-empty row</source>
         <translation>Prima riga non vuota</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="721"/>
+        <location filename="../settings/settingsdialog.ui" line="820"/>
         <source>Number column</source>
         <translation>Colonna numeri</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="728"/>
+        <location filename="../settings/settingsdialog.ui" line="827"/>
         <source>Model column</source>
         <translation>Colonna modelli</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="772"/>
+        <location filename="../settings/settingsdialog.ui" line="871"/>
         <source>Sheet Export</source>
         <translation>Esportazione Fogli</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="778"/>
+        <location filename="../settings/settingsdialog.ui" line="877"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="784"/>
+        <location filename="../settings/settingsdialog.ui" line="883"/>
         <source>Header</source>
         <translation>Intestazione</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="791"/>
+        <location filename="../settings/settingsdialog.ui" line="890"/>
         <source>Footer</source>
         <translation>Piè pagina</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="807"/>
+        <location filename="../settings/settingsdialog.ui" line="906"/>
         <source>Metadata</source>
         <translation>Metadati</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="813"/>
+        <location filename="../settings/settingsdialog.ui" line="912"/>
         <source>Store meeting location and dates in sheet metadata</source>
         <translation>Salva città e date del meeting nei metadati del foglio</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="837"/>
+        <location filename="../settings/settingsdialog.ui" line="936"/>
         <source>Background Tasks</source>
         <translation>Task in background</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="843"/>
+        <location filename="../settings/settingsdialog.ui" line="942"/>
         <source>Rollingstock Error Checker</source>
         <translation>Controllo errori Rotabili</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="849"/>
+        <location filename="../settings/settingsdialog.ui" line="948"/>
         <source>Check rollingstock when opening a file</source>
         <translation>Controlla rotabili quando viene aperto un file</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="856"/>
+        <location filename="../settings/settingsdialog.ui" line="955"/>
         <source>Check rollingstock when a Job is edeited</source>
         <translation>Controlla rotabili quando viene modificato un servizio</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="79"/>
+        <location filename="../settings/settingsdialog.cpp" line="81"/>
         <source>Job Colors</source>
         <translation>Colori Servizi</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="458"/>
+        <location filename="../settings/settingsdialog.ui" line="557"/>
         <source>Stop</source>
         <translation>Fermata</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="470"/>
+        <location filename="../settings/settingsdialog.ui" line="569"/>
         <source>Default Stop Duration</source>
         <translation>Durata Fermata Predefinita</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="486"/>
+        <location filename="../settings/settingsdialog.ui" line="585"/>
         <source>Job Editor</source>
         <translation>Editor Servizi</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="509"/>
+        <location filename="../settings/settingsdialog.ui" line="608"/>
         <source>Auto uncouple all rollingstock items at last stop.</source>
         <translation>Sgancia automaticamente tutti i rotabili nell&apos;ultima fermata.</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="502"/>
+        <location filename="../settings/settingsdialog.ui" line="601"/>
         <source>Auto move uncoupled rollingstock pieces from last stop when adding a new one.</source>
         <translation>Sposta automaticamente i rotabili sganciati dall&apos;ultima fermata quando ne viene aggiunta una nuova.</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="533"/>
+        <location filename="../settings/settingsdialog.ui" line="74"/>
+        <source>Application Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="86"/>
+        <location filename="../settings/settingsdialog.ui" line="147"/>
+        <source>Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="122"/>
+        <source>Application Language changes will be applied next time you start the application!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="135"/>
+        <source>Sheet Export Language:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="183"/>
+        <source>This is the language for exported sheets. It will be reset at every launch to same language of application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="193"/>
+        <source>Reset to Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../settings/settingsdialog.ui" line="632"/>
         <source>Shift Graph</source>
         <translation>Grafico Turni</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="595"/>
+        <location filename="../settings/settingsdialog.ui" line="694"/>
         <source>Job Box</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="605"/>
+        <location filename="../settings/settingsdialog.ui" line="704"/>
         <source>Stations Labels</source>
         <translation>Etichette stazioni</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="615"/>
+        <location filename="../settings/settingsdialog.ui" line="714"/>
         <source>Hide Same Stations</source>
         <translation>Nascondi stesse stazioni</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="642"/>
+        <location filename="../settings/settingsdialog.ui" line="741"/>
         <source>Rollingstock</source>
         <translation>Rotabili</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="654"/>
+        <location filename="../settings/settingsdialog.ui" line="753"/>
         <source>Merge models</source>
         <translation>Unisci Modelli</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="663"/>
+        <location filename="../settings/settingsdialog.ui" line="762"/>
         <source>Remove source merged model by default</source>
         <translation>Rimuovi di default il proprietario d&apos;origine</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="679"/>
+        <location filename="../settings/settingsdialog.ui" line="778"/>
         <source>Merge owners</source>
         <translation>Unisci Proprietari</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.ui" line="688"/>
+        <location filename="../settings/settingsdialog.ui" line="787"/>
         <source>Remove sourcemerged owner by default</source>
         <translation>Rimuovi di default il modello d&apos;origine</translation>
     </message>
     <message>
         <location filename="../settings/settingsdialog.ui" line="32"/>
-        <location filename="../settings/settingsdialog.cpp" line="338"/>
-        <location filename="../settings/settingsdialog.cpp" line="356"/>
+        <location filename="../settings/settingsdialog.cpp" line="366"/>
+        <location filename="../settings/settingsdialog.cpp" line="384"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="30"/>
+        <location filename="../settings/settingsdialog.cpp" line="32"/>
         <source>minutes</source>
         <translation>minuti</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="84"/>
+        <location filename="../settings/settingsdialog.cpp" line="86"/>
         <source>Non Passenger</source>
         <translation>Non Passeggeri</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="96"/>
+        <location filename="../settings/settingsdialog.cpp" line="98"/>
         <source>Passenger</source>
         <translation>Passeggeri</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="339"/>
+        <location filename="../settings/settingsdialog.cpp" line="367"/>
         <source>Do you want to save settings?</source>
         <translation>Vuoi salvare le impostazioni?</translation>
     </message>
     <message>
-        <location filename="../settings/settingsdialog.cpp" line="357"/>
+        <location filename="../settings/settingsdialog.cpp" line="385"/>
         <source>Do you want to restore default settings?</source>
         <translation>Vuoi ripristinare le impostazioni predefinite?</translation>
     </message>

--- a/src/translations/mrtp_it.ts
+++ b/src/translations/mrtp_it.ts
@@ -912,84 +912,89 @@ NOTA: i tempi di sosta non sono affetti da questa modifica ma perderai gli aggiu
         <translation>Salva Foglio</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="222"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="223"/>
         <source>Toggle transit</source>
         <translation>Commuta transito</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="229"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="230"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="226"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="227"/>
         <source>Edit stop</source>
         <translation>Modifica fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="223"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="224"/>
         <source>Set transit</source>
         <translation>Imposta transito</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="224"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="225"/>
         <source>Unset transit</source>
         <translation>Togli transito</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="228"/>
         <source>Station SVG Plan</source>
         <translation>Piano SVG Stazione</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="365"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="366"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="366"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="367"/>
         <source>You must register at least 2 stops.
 Do you want to delete this job?</source>
         <translation>Devi registrare almeno 2 fermate.
 Vuoi eliminare questo servizio?</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="481"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="482"/>
         <source>Save?</source>
         <translation>Salvare?</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="482"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="483"/>
         <source>Do you want to save changes to job %1</source>
         <translation>Vuoi salvare le modifiche fatte al servizio %1</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="169"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="643"/>
+        <source>Job Sheet Saved</source>
+        <translation>Foglio Servizio Salvato</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="170"/>
         <source>Invalid</source>
         <translation>Non valido</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="170"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="171"/>
         <source>Job number &lt;b&gt;%1&lt;/b&gt; is already exists.&lt;br&gt;Please choose a different number.</source>
         <translation>Il servizio numero &lt;b&gt;%1&lt;/b&gt; è già esistente.&lt;br&gt;Per favore scegli un numero diverso.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="574"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="575"/>
         <source>Empty Job</source>
         <translation>Servizio vuoto</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="575"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="576"/>
         <source>Before setting a shift you should add stops to this job</source>
         <translation>Prima di selezionare un turno dovresti aggiungere le fermate</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="620"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="621"/>
         <source>Save Job Sheet</source>
         <translation>Salva Foglio Servizio</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="624"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="625"/>
         <source>job%1_sheet.odt</source>
         <translation>foglio_treno%1.odt</translation>
     </message>
@@ -2025,76 +2030,106 @@ Estensione: (*.ods)</translation>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="643"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="362"/>
         <source>Arrival</source>
         <translation>Arrivo</translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="644"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="249"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="363"/>
         <source>Departure</source>
         <translation>Partenza</translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="645"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="248"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="365"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="377"/>
         <source>Platf</source>
         <translation>Bin</translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="646"/>
         <location filename="../odt_export/common/sessionrswriter.cpp" line="246"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="368"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="380"/>
         <source>Rollingstock</source>
         <translation>Rotabili</translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="647"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="369"/>
         <source>Crossings</source>
         <translation>Incroci</translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="648"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="370"/>
         <source>Passings</source>
         <translation>Precedenze</translation>
     </message>
     <message>
         <location filename="../odt_export/common/jobwriter.cpp" line="649"/>
-        <location filename="../odt_export/common/stationwriter.cpp" line="371"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="383"/>
         <source>Notes</source>
         <translation>Note</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="584"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="599"/>
         <source>Transit</source>
         <translation>Transito</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="311"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="327"/>
         <source>Station: %1%2</source>
         <translation>Stazione %1%2</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="315"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="322"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="364"/>
-        <source>Job N</source>
-        <translation>Treno N</translation>
+        <location filename="../odt_export/common/stationwriter.cpp" line="374"/>
+        <source>Arr.</source>
+        <comment>Arrival column</comment>
+        <translation>Arr.</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="366"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="375"/>
+        <source>Dep.</source>
+        <comment>Departure column</comment>
+        <translation>Part.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="376"/>
+        <source>Job Nr</source>
+        <translation>Treno N.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="381"/>
+        <source>Cross</source>
+        <comment>Crossings column</comment>
+        <translation>Incrocia</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="382"/>
+        <source>Passings</source>
+        <comment>Passings column</comment>
+        <translation>Prec.</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="610"/>
+        <source>START</source>
+        <comment>Do not translate this text</comment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Job N</source>
+        <translation type="vanished">Treno N</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/stationwriter.cpp" line="378"/>
         <source>From</source>
         <translation>Da</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/stationwriter.cpp" line="367"/>
+        <location filename="../odt_export/common/stationwriter.cpp" line="379"/>
         <source>To</source>
         <translation>Per</translation>
     </message>
@@ -2135,12 +2170,12 @@ Estensione: (*.ods)</translation>
         <translation>fine</translation>
     </message>
     <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="420"/>
+        <location filename="../odt_export/shiftsheetexport.cpp" line="422"/>
         <source>From %1 to %2</source>
         <translation>Dal %1 al %2</translation>
     </message>
     <message>
-        <location filename="../odt_export/shiftsheetexport.cpp" line="479"/>
+        <location filename="../odt_export/shiftsheetexport.cpp" line="481"/>
         <source>SHIFT %1</source>
         <translation>TURNO %1</translation>
     </message>
@@ -3833,39 +3868,44 @@ Estensione: (*.ttt)</translation>
 <context>
     <name>SessionStartEndRSViewer</name>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="31"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="32"/>
         <source>Show Session Start</source>
         <translation>Mostra Inizio Sessione</translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="32"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="33"/>
         <source>Show Session End</source>
         <translation>Mostra Fine Sessione</translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="36"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="37"/>
         <source>Order By Station</source>
         <translation>Ordina per Stazione</translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="37"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="38"/>
         <source>Order By Owner</source>
         <translation>Ordina per Proprietario</translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="43"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="44"/>
         <source>Export Sheet</source>
         <translation>Esporta Foglio</translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="60"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="61"/>
         <source>Rollingstock Summary</source>
         <translation>Riassunto Rotabili</translation>
     </message>
     <message>
-        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="81"/>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="82"/>
         <source>Expoert RS session plan</source>
         <translation>Esporta il piano rotabili della sessione</translation>
+    </message>
+    <message>
+        <location filename="../viewmanager/sessionstartendrsviewer.cpp" line="102"/>
+        <source>Session RS Plan Saved</source>
+        <translation>Piano Ratabili Sessione Salvato</translation>
     </message>
 </context>
 <context>
@@ -4208,34 +4248,39 @@ Estensione: (*.ttt)</translation>
 <context>
     <name>ShiftGraphEditor</name>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="36"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="37"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="37"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="38"/>
         <source>Print</source>
         <translation>Stampa</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="38"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="39"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="39"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="40"/>
         <source>Refresh</source>
         <translation>Ricarica</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="55"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="56"/>
         <source>Shift Graph Editor</source>
         <translation>Editor Grafico Turni</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="65"/>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="66"/>
         <source>Save Shift Graph</source>
         <translation>Salva Grafico Turni</translation>
+    </message>
+    <message>
+        <location filename="../shifts/shiftgraph/shiftgrapheditor.cpp" line="93"/>
+        <source>Shift Graph Saved</source>
+        <translation>Grafico Turni Salvato</translation>
     </message>
 </context>
 <context>
@@ -4278,91 +4323,96 @@ Estensione: (*.ttt)</translation>
 <context>
     <name>ShiftManager</name>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="52"/>
+        <location filename="../shifts/shiftmanager.cpp" line="53"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="53"/>
+        <location filename="../shifts/shiftmanager.cpp" line="54"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="55"/>
+        <location filename="../shifts/shiftmanager.cpp" line="56"/>
         <source>View Shift</source>
         <translation>Vedi Turno</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="56"/>
+        <location filename="../shifts/shiftmanager.cpp" line="57"/>
         <source>Sheet</source>
         <translation>Foglio</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="58"/>
+        <location filename="../shifts/shiftmanager.cpp" line="59"/>
         <source>Graph</source>
         <translation>Grafico</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="72"/>
+        <location filename="../shifts/shiftmanager.cpp" line="73"/>
         <source>Create new Job Shift</source>
         <translation>Crea nuovo Turno Servizi</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="73"/>
+        <location filename="../shifts/shiftmanager.cpp" line="74"/>
         <source>Remove selected Job Shift</source>
         <translation>Rimuovi il Turno Servizi selezionato</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="74"/>
+        <location filename="../shifts/shiftmanager.cpp" line="75"/>
         <source>Show selected Job Shift plan</source>
         <translation>Mostra il piano del Turno Servizi selezionato</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="75"/>
+        <location filename="../shifts/shiftmanager.cpp" line="76"/>
         <source>Save selected Job Shift plan on file</source>
         <translation>Salva il Turno Servizi selezionato su file</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="76"/>
+        <location filename="../shifts/shiftmanager.cpp" line="77"/>
         <source>Show Job Shift graph</source>
         <translation>Mostra grafico Turni Servizi</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="78"/>
+        <location filename="../shifts/shiftmanager.cpp" line="79"/>
         <source>Shift Manager</source>
         <translation>Manager Turno</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="117"/>
+        <location filename="../shifts/shiftmanager.cpp" line="118"/>
         <source>Error Adding Shift</source>
         <translation>Errore nell&apos;aggiungere Turno</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="118"/>
+        <location filename="../shifts/shiftmanager.cpp" line="119"/>
         <source>An error occurred while adding a new shift:
 %1</source>
         <translation>Errore nell&apos;aggiungere un nuovo turno:
 %1</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="138"/>
+        <location filename="../shifts/shiftmanager.cpp" line="139"/>
         <source>Remove Shift?</source>
         <translation>Rimuovere Turno?</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="139"/>
+        <location filename="../shifts/shiftmanager.cpp" line="140"/>
         <source>Are you sure you want to remove Job Shift &lt;b&gt;%1&lt;/b&gt;?</source>
         <translation>Sei sicuro di voler rimuovere il Turno Servizi &lt;b&gt;%1&lt;/b&gt;?</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="189"/>
+        <location filename="../shifts/shiftmanager.cpp" line="190"/>
         <source>Save Shift Sheet</source>
         <translation>Salva Foglio Turno</translation>
     </message>
     <message>
-        <location filename="../shifts/shiftmanager.cpp" line="193"/>
+        <location filename="../shifts/shiftmanager.cpp" line="194"/>
         <source>shift_%1.odt</source>
         <translation>turno_%1.odt</translation>
+    </message>
+    <message>
+        <location filename="../shifts/shiftmanager.cpp" line="211"/>
+        <source>Shift Sheet Saved</source>
+        <translation>Foglio Turno Salvato</translation>
     </message>
 </context>
 <context>
@@ -4890,24 +4940,29 @@ Può anche essere entrambi (Bidirezionale) ma non può non essere nessuno dei du
         <translation>Salva foglio</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="90"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="91"/>
         <source>Show in Job Editor</source>
         <translation>Mostra nell&apos;Editor Servizio</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="91"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="92"/>
         <source>Show job in graph</source>
         <translation>Mostra nel grafico servizi</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="110"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="111"/>
         <source>Save Station Sheet</source>
         <translation>Salva Foglio Stazione</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationjobview.cpp" line="114"/>
+        <location filename="../stations/manager/stationjobview.cpp" line="115"/>
         <source>%1_station.odt</source>
         <translation>stazione_%1.odt</translation>
+    </message>
+    <message>
+        <location filename="../stations/manager/stationjobview.cpp" line="133"/>
+        <source>Station Sheet Saved</source>
+        <translation>Foglio Stazione Salvato</translation>
     </message>
 </context>
 <context>
@@ -5591,6 +5646,24 @@ Per favore scegli un altro Binario o cambia la Tratta successiva.</translation>
         <location filename="../viewmanager/viewmanager.cpp" line="648"/>
         <source>Are you sure you want to remove Job &lt;b&gt;%1&lt;/b&gt;?</source>
         <translation>Sei sicuro di voler rimuovere il Servizio &lt;b&gt;%1&lt;/b&gt;?</translation>
+    </message>
+</context>
+<context>
+    <name>utils::OpenFileInFolderDlg</name>
+    <message>
+        <location filename="../utils/openfileinfolder.cpp" line="54"/>
+        <source>Open In App</source>
+        <translation>Apri in App</translation>
+    </message>
+    <message>
+        <location filename="../utils/openfileinfolder.cpp" line="55"/>
+        <source>Show Folder</source>
+        <translation>Mostra Cartella</translation>
+    </message>
+    <message>
+        <location filename="../utils/openfileinfolder.cpp" line="84"/>
+        <source>Do you want to open file?&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</source>
+        <translation>Vuoi aprire il file?&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</translation>
     </message>
 </context>
 </TS>

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MR_TIMETABLE_PLANNER_SOURCES
   utils/types.h
   utils/combodelegate.h
   utils/model_roles.h
+  utils/openfileinfolder.h
   utils/worker_event_types.h
 
   utils/colordelegate.cpp
@@ -25,6 +26,7 @@ set(MR_TIMETABLE_PLANNER_SOURCES
   utils/combodelegate.cpp
   utils/imageviewer.cpp
   utils/kmutils.cpp
+  utils/openfileinfolder.cpp
   utils/rs_utils.cpp
   PARENT_SCOPE
 )

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MR_TIMETABLE_PLANNER_SOURCES
   utils/imageviewer.h
   utils/jobcategorystrings.h
   utils/kmutils.h
+  utils/languageutils.h
   utils/owningqpointer.h
   utils/rs_types_names.h
   utils/rs_utils.h
@@ -26,6 +27,7 @@ set(MR_TIMETABLE_PLANNER_SOURCES
   utils/combodelegate.cpp
   utils/imageviewer.cpp
   utils/kmutils.cpp
+  utils/languageutils.cpp
   utils/openfileinfolder.cpp
   utils/rs_utils.cpp
   PARENT_SCOPE

--- a/src/utils/jobcategorystrings.h
+++ b/src/utils/jobcategorystrings.h
@@ -60,6 +60,11 @@ public:
     {
         return shortName(cat) + QString::number(jobId); //Example: LIS1234
     }
+
+    static inline QString jobNameSpaced(db_id jobId, JobCategory cat)
+    {
+        return shortName(cat) + QChar(' ') + QString::number(jobId); //Example: LIS1234
+    }
 };
 
 #endif // JOBCATEGORYSTRINGS_H

--- a/src/utils/languageutils.cpp
+++ b/src/utils/languageutils.cpp
@@ -34,7 +34,7 @@ QTranslator *utils::language::loadAppTranslator(const QLocale &loc)
 bool utils::language::loadTranslationsFromSettings()
 {
     const QString path = qApp->applicationDirPath() + translationsFolder;
-    QLocale loc = AppSettings.getLanguage();
+    QLocale loc = Session->getAppLanguage();
 
     //NOTE: If locale is English with default country we do not need translations
     //because they are already embedded in the executable strings so skip it

--- a/src/utils/languageutils.cpp
+++ b/src/utils/languageutils.cpp
@@ -5,9 +5,13 @@
 
 #include "app/session.h"
 
+#include <QDirIterator>
+#include <QVector>
+
 #include <QDebug>
 
-constexpr const char *mrtpTranslationPrefix = "mrtp";
+constexpr const char *mrtpTranslationName = "mrtp";
+static const QLatin1String translationsFolder = QLatin1String("/translations");
 
 static inline QTranslator *loadTranslatorInternal(const QLocale &loc, const QString& path, const QString& prefix)
 {
@@ -23,14 +27,19 @@ static inline QTranslator *loadTranslatorInternal(const QLocale &loc, const QStr
 
 QTranslator *utils::language::loadAppTranslator(const QLocale &loc)
 {
-    const QString path = qApp->applicationDirPath() + QStringLiteral("/translations");
-    return ::loadTranslatorInternal(loc, path, QString::fromLatin1(mrtpTranslationPrefix));
+    const QString path = qApp->applicationDirPath() + translationsFolder;
+    return ::loadTranslatorInternal(loc, path, QString::fromLatin1(mrtpTranslationName));
 }
 
 bool utils::language::loadTranslationsFromSettings()
 {
+    const QString path = qApp->applicationDirPath() + translationsFolder;
     QLocale loc = AppSettings.getLanguage();
-    const QString path = qApp->applicationDirPath() + QStringLiteral("/translations");
+
+    //NOTE: If locale is English with default country we do not need translations
+    //because they are already embedded in the executable strings so skip it
+    if(loc == QLocale(QLocale::English))
+        return true;
 
     QTranslator *qtTransl = ::loadTranslatorInternal(loc, path, QLatin1String("qt"));
     if(qtTransl)
@@ -38,7 +47,7 @@ bool utils::language::loadTranslationsFromSettings()
         QCoreApplication::installTranslator(qtTransl);
     }
 
-    QTranslator *mrtpTransl = ::loadTranslatorInternal(loc, path, QString::fromLatin1(mrtpTranslationPrefix));
+    QTranslator *mrtpTransl = ::loadTranslatorInternal(loc, path, QString::fromLatin1(mrtpTranslationName));
     if(mrtpTransl)
     {
         QCoreApplication::installTranslator(mrtpTransl);
@@ -46,4 +55,37 @@ bool utils::language::loadTranslationsFromSettings()
     }
 
     return false;
+}
+
+QVector<QLocale> utils::language::getAvailableTranslations()
+{
+    QVector<QLocale> vec;
+
+    //NOTE: Add English with default country which is embedded  in executable strings
+    vec.append(QLocale(QLocale::English));
+
+    const QString path = qApp->applicationDirPath() + translationsFolder;
+    const QString filter = mrtpTranslationName + QStringLiteral("_*.qm");
+    const int startIdx = qstrlen(mrtpTranslationName) + 1; //Add the '_'
+
+    //Get all installed translation files
+    QDirIterator iter(path, {filter}, QDir::Files);
+    while (iter.hasNext())
+    {
+        iter.next();
+        const QString fullName = iter.fileName();
+        int lastIdx = fullName.indexOf('.');
+        if(lastIdx < 0)
+            continue; //Skip invalid name
+
+        //Extract language from file name
+        QString language = fullName.mid(startIdx, lastIdx - startIdx);
+        QLocale loc(language);
+        if(loc == QLocale::c())
+            continue; //This means it didn't parse locale
+
+        vec.append(loc);
+    }
+
+    return vec;
 }

--- a/src/utils/languageutils.cpp
+++ b/src/utils/languageutils.cpp
@@ -1,0 +1,49 @@
+#include "languageutils.h"
+
+#include <QCoreApplication>
+#include <QTranslator>
+
+#include "app/session.h"
+
+#include <QDebug>
+
+constexpr const char *mrtpTranslationPrefix = "mrtp";
+
+static inline QTranslator *loadTranslatorInternal(const QLocale &loc, const QString& path, const QString& prefix)
+{
+    QTranslator *translator = new QTranslator(qApp);
+    if(!translator->load(loc, prefix, QStringLiteral("_"), path))
+    {
+        qDebug() << "Cannot load translations for:" << prefix.toUpper() << loc.name() << loc.uiLanguages();
+        delete translator;
+        return nullptr;
+    }
+    return translator;
+}
+
+QTranslator *utils::language::loadAppTranslator(const QLocale &loc)
+{
+    const QString path = qApp->applicationDirPath() + QStringLiteral("/translations");
+    return ::loadTranslatorInternal(loc, path, QString::fromLatin1(mrtpTranslationPrefix));
+}
+
+bool utils::language::loadTranslationsFromSettings()
+{
+    QLocale loc = AppSettings.getLanguage();
+    const QString path = qApp->applicationDirPath() + QStringLiteral("/translations");
+
+    QTranslator *qtTransl = ::loadTranslatorInternal(loc, path, QLatin1String("qt"));
+    if(qtTransl)
+    {
+        QCoreApplication::installTranslator(qtTransl);
+    }
+
+    QTranslator *mrtpTransl = ::loadTranslatorInternal(loc, path, QString::fromLatin1(mrtpTranslationPrefix));
+    if(mrtpTransl)
+    {
+        QCoreApplication::installTranslator(mrtpTransl);
+        return true;
+    }
+
+    return false;
+}

--- a/src/utils/languageutils.cpp
+++ b/src/utils/languageutils.cpp
@@ -38,7 +38,7 @@ bool utils::language::loadTranslationsFromSettings()
 
     //NOTE: If locale is English with default country we do not need translations
     //because they are already embedded in the executable strings so skip it
-    if(loc == QLocale(QLocale::English))
+    if(loc == MeetingSession::embeddedLocale)
         return true;
 
     QTranslator *qtTransl = ::loadTranslatorInternal(loc, path, QLatin1String("qt"));
@@ -61,8 +61,8 @@ QVector<QLocale> utils::language::getAvailableTranslations()
 {
     QVector<QLocale> vec;
 
-    //NOTE: Add English with default country which is embedded  in executable strings
-    vec.append(QLocale(QLocale::English));
+    //NOTE: First add default laguage embedded in executable strings
+    vec.append(MeetingSession::embeddedLocale);
 
     const QString path = qApp->applicationDirPath() + translationsFolder;
     const QString filter = mrtpTranslationName + QStringLiteral("_*.qm");

--- a/src/utils/languageutils.h
+++ b/src/utils/languageutils.h
@@ -4,6 +4,9 @@
 class QTranslator;
 class QLocale;
 
+template<typename T>
+class QVector;
+
 namespace utils {
 
 namespace language {
@@ -11,6 +14,8 @@ namespace language {
 QTranslator *loadAppTranslator(const QLocale& loc);
 
 bool loadTranslationsFromSettings();
+
+QVector<QLocale> getAvailableTranslations();
 
 } // namespace language
 

--- a/src/utils/languageutils.h
+++ b/src/utils/languageutils.h
@@ -1,0 +1,19 @@
+#ifndef LANGUAGEUTILS_H
+#define LANGUAGEUTILS_H
+
+class QTranslator;
+class QLocale;
+
+namespace utils {
+
+namespace language {
+
+QTranslator *loadAppTranslator(const QLocale& loc);
+
+bool loadTranslationsFromSettings();
+
+} // namespace language
+
+} // namespace utils
+
+#endif // LANGUAGEUTILS_H

--- a/src/utils/openfileinfolder.cpp
+++ b/src/utils/openfileinfolder.cpp
@@ -1,24 +1,22 @@
 #include "openfileinfolder.h"
 
-#include <QCoreApplication>
 #include <QFileInfo>
+#include <QDir>
 #include <QUrl>
 
 #include <QProcess>
 #include <QDesktopServices>
 
-#include "utils/owningqpointer.h"
-#include <QMessageBox>
+#include <QVBoxLayout>
 #include <QPushButton>
+#include <QLabel>
+#include <QDialogButtonBox>
+
+#include "utils/owningqpointer.h"
 
 namespace utils {
 
-class OpenFileInFolder
-{
-    Q_DECLARE_TR_FUNCTIONS(OpenFileInFolder)
-};
-
-bool openFileInFolder(const QFileInfo& info, bool folder)
+static bool openDefAppOrShowFolder(const QFileInfo& info, bool folder)
 {
     if(info.isDir())
         folder = true;
@@ -26,44 +24,76 @@ bool openFileInFolder(const QFileInfo& info, bool folder)
     QString path = folder ? info.absolutePath() : info.absoluteFilePath();
 
 #if defined(Q_OS_WIN) && !defined (Q_OS_WINRT)
-    if(!folder)
+    if(folder && !info.isDir())
     {
-        QString args = QStringLiteral("/select,%1").arg(path);
+        //NOTE: on Windows desktop we can also select a file inside a folder
+        //So prefer it instead of default QDesktopServices
+        QString args = QStringLiteral("/select,%1").arg(QDir::toNativeSeparators(info.absoluteFilePath()));
         QProcess explorer;
         explorer.setProgram(QLatin1String("explorer.exe"));
         explorer.setNativeArguments(args); //This must not be quoted
-        return explorer.startDetached();
+        if(explorer.startDetached())
+            return true;
     }
 #endif
 
     return QDesktopServices::openUrl(QUrl::fromLocalFile(path));
 }
 
-} //namespace utils
-
-void utils::openFileInFolder(const QString &title, const QString &filePath, QWidget *parent)
+OpenFileInFolderDlg::OpenFileInFolderDlg(QWidget *parent) :
+    QDialog(parent)
 {
-    QFileInfo info(filePath);
+    QVBoxLayout *lay = new QVBoxLayout(this);
 
-    OwningQPointer<QMessageBox> msgBox = new QMessageBox(parent);
-    msgBox->setIcon(QMessageBox::Information);
-    msgBox->setWindowTitle(title);
-    msgBox->setText(OpenFileInFolder::tr("Do you want to open file?<br><b>%1</b>").arg(info.canonicalFilePath()));
+    mLabel = new QLabel;
+    lay->addWidget(mLabel);
 
-    QPushButton *openFileBut = nullptr;
-    if(info.isFile())
-        openFileBut = msgBox->addButton(OpenFileInFolder::tr("Open In App"), QMessageBox::AcceptRole);
-    QPushButton *folderBut = msgBox->addButton(OpenFileInFolder::tr("Show Folder"), QMessageBox::AcceptRole);
-    msgBox->addButton(QMessageBox::Ok);
-    if(msgBox->exec() != QMessageBox::Accepted || !msgBox)
-        return;
+    QDialogButtonBox *box = new QDialogButtonBox(Qt::Horizontal);
+    lay->addWidget(box);
 
-    if(openFileBut && msgBox->clickedButton() == openFileBut)
-    {
-        openFileInFolder(info, false);
-    }
-    else if(msgBox->clickedButton() == folderBut)
-    {
-        openFileInFolder(info, true);
-    }
+    openFileBut = box->addButton(tr("Open In App"), QDialogButtonBox::AcceptRole);
+    openFolderBut = box->addButton(tr("Show Folder"), QDialogButtonBox::AcceptRole);
+    QPushButton *okBut = box->addButton(QDialogButtonBox::Ok);
+
+    //Open Folder by default
+    openFolderBut->setDefault(true);
+    openFolderBut->setFocus();
+
+    //Only close dialog with Ok button, ignore others
+    connect(okBut, &QPushButton::clicked, this, &QDialog::accept);
+    connect(openFileBut, &QPushButton::clicked, this, &OpenFileInFolderDlg::onOpenFile);
+    connect(openFolderBut, &QPushButton::clicked, this, &OpenFileInFolderDlg::onOpenFolder);
 }
+
+void OpenFileInFolderDlg::setFilePath(const QString &newFilePath)
+{
+    info.setFile(newFilePath);
+    openFileBut->setVisible(info.isFile());
+}
+
+void OpenFileInFolderDlg::setLabelText(const QString &text)
+{
+    mLabel->setText(text);
+}
+
+void OpenFileInFolderDlg::askUser(const QString &title, const QString &filePath, QWidget *parent)
+{
+    OwningQPointer<OpenFileInFolderDlg> dlg = new OpenFileInFolderDlg(parent);
+    dlg->setWindowTitle(title);
+    dlg->setFilePath(filePath);
+    dlg->setLabelText(OpenFileInFolderDlg::tr("Do you want to open file?<br><b>%1</b>")
+                          .arg(dlg->getInfo().canonicalFilePath()));
+    dlg->exec();
+}
+
+void OpenFileInFolderDlg::onOpenFile()
+{
+    openDefAppOrShowFolder(info, false);
+}
+
+void OpenFileInFolderDlg::onOpenFolder()
+{
+    openDefAppOrShowFolder(info, true);
+}
+
+} //namespace utils

--- a/src/utils/openfileinfolder.cpp
+++ b/src/utils/openfileinfolder.cpp
@@ -1,0 +1,69 @@
+#include "openfileinfolder.h"
+
+#include <QCoreApplication>
+#include <QFileInfo>
+#include <QUrl>
+
+#include <QProcess>
+#include <QDesktopServices>
+
+#include "utils/owningqpointer.h"
+#include <QMessageBox>
+#include <QPushButton>
+
+namespace utils {
+
+class OpenFileInFolder
+{
+    Q_DECLARE_TR_FUNCTIONS(OpenFileInFolder)
+};
+
+bool openFileInFolder(const QFileInfo& info, bool folder)
+{
+    if(info.isDir())
+        folder = true;
+
+    QString path = folder ? info.absolutePath() : info.absoluteFilePath();
+
+#if defined(Q_OS_WIN) && !defined (Q_OS_WINRT)
+    if(!folder)
+    {
+        QString args = QStringLiteral("/select,%1").arg(path);
+        QProcess explorer;
+        explorer.setProgram(QLatin1String("explorer.exe"));
+        explorer.setNativeArguments(args); //This must not be quoted
+        return explorer.startDetached();
+    }
+#endif
+
+    return QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+}
+
+} //namespace utils
+
+void utils::openFileInFolder(const QString &title, const QString &filePath, QWidget *parent)
+{
+    QFileInfo info(filePath);
+
+    OwningQPointer<QMessageBox> msgBox = new QMessageBox(parent);
+    msgBox->setIcon(QMessageBox::Information);
+    msgBox->setWindowTitle(title);
+    msgBox->setText(OpenFileInFolder::tr("Do you want to open file?<br><b>%1</b>").arg(info.canonicalFilePath()));
+
+    QPushButton *openFileBut = nullptr;
+    if(info.isFile())
+        openFileBut = msgBox->addButton(OpenFileInFolder::tr("Open In App"), QMessageBox::AcceptRole);
+    QPushButton *folderBut = msgBox->addButton(OpenFileInFolder::tr("Show Folder"), QMessageBox::AcceptRole);
+    msgBox->addButton(QMessageBox::Ok);
+    if(msgBox->exec() != QMessageBox::Accepted || !msgBox)
+        return;
+
+    if(openFileBut && msgBox->clickedButton() == openFileBut)
+    {
+        openFileInFolder(info, false);
+    }
+    else if(msgBox->clickedButton() == folderBut)
+    {
+        openFileInFolder(info, true);
+    }
+}

--- a/src/utils/openfileinfolder.h
+++ b/src/utils/openfileinfolder.h
@@ -1,13 +1,59 @@
 #ifndef OPENFILEINFOLDER_H
 #define OPENFILEINFOLDER_H
 
-#include <QString>
+#include <QDialog>
 
-class QWidget;
+#include <QFileInfo>
+
+class QLabel;
+class QPushButton;
 
 namespace utils {
 
-void openFileInFolder(const QString& title, const QString& filePath, QWidget *parent);
+/*!
+ * \brief The OpenFileInFolderDlg class
+ *
+ * A small dialog to open file of folder in default app or show its
+ * containing folder in system file manager
+ *
+ * This does not use QMessageBox because it would close
+ * when user clicks any button.
+ * This dialogs instead closes only with Ok button
+ *
+ * Windows: special case, it can also select a file inside explorer.exe
+ */
+class OpenFileInFolderDlg : public QDialog
+{
+    Q_OBJECT
+public:
+    OpenFileInFolderDlg(QWidget *parent = nullptr);
+
+    void setFilePath(const QString &newFilePath);
+    void setLabelText(const QString &text);
+
+    inline QFileInfo getInfo() const { return info; }
+
+    /*!
+     * \brief askUser
+     * \param title dialog title
+     * \param filePath file or folder to open
+     * \param parent parent window
+     *
+     * This convinience function opens standard dialog with default text
+     */
+    static void askUser(const QString& title, const QString& filePath, QWidget *parent);
+
+private slots:
+    void onOpenFile();
+    void onOpenFolder();
+
+private:
+    QLabel *mLabel;
+    QPushButton *openFileBut;
+    QPushButton *openFolderBut;
+
+    QFileInfo info;
+};
 
 }
 

--- a/src/utils/openfileinfolder.h
+++ b/src/utils/openfileinfolder.h
@@ -1,0 +1,14 @@
+#ifndef OPENFILEINFOLDER_H
+#define OPENFILEINFOLDER_H
+
+#include <QString>
+
+class QWidget;
+
+namespace utils {
+
+void openFileInFolder(const QString& title, const QString& filePath, QWidget *parent);
+
+}
+
+#endif // OPENFILEINFOLDER_H

--- a/src/utils/openfileinfolder.h
+++ b/src/utils/openfileinfolder.h
@@ -48,7 +48,8 @@ private slots:
     void onOpenFolder();
 
 private:
-    QLabel *mLabel;
+    QLabel *mDescrLabel;
+    QLabel *mIconLabel;
     QPushButton *openFileBut;
     QPushButton *openFolderBut;
 

--- a/src/viewmanager/sessionstartendrsviewer.cpp
+++ b/src/viewmanager/sessionstartendrsviewer.cpp
@@ -14,6 +14,7 @@
 #include "app/session.h"
 
 #include "odt_export/sessionrsexport.h"
+#include "utils/openfileinfolder.h"
 
 #include "utils/file_format_names.h"
 
@@ -97,4 +98,6 @@ void SessionStartEndRSViewer::exportSheet()
     SessionRSExport w(model->mode(), model->order());
     w.write();
     w.save(fileName);
+
+    utils::OpenFileInFolderDlg::askUser(tr("Session RS Plan Saved"), fileName, this);
 }


### PR DESCRIPTION
This PR has a bunch of fixes for Sheet Exportation:

- Fix queries to database
- Vertical align to middle for cells in exported Station and Job sheets
- New dialog which allows to open resulting file upon exportation success
- Settings: dynamically load available translations (more robust logic)
- Allow Exporting Sheet in a different language than Application Language (closes #17)