### PR TITLE
Feature detect direction change

### DIFF
--- a/files/icons/reverse_direction/reverse_direction.svg
+++ b/files/icons/reverse_direction/reverse_direction.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="100mm"
+   height="100mm"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1">
+    <path
+       style="fill:none;stroke:#00aa00;stroke-width:18.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 25,85 V 35 C 25.100727,6.7404564 75.224095,7.2276899 75,35 v 35"
+       id="path876" />
+    <path
+       style="fill:#00aa00;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 53,70 H 97 L 75,96 Z"
+       id="path2659" />
+  </g>
+</svg>

--- a/files/icons/reverse_direction/reverse_direction.svg
+++ b/files/icons/reverse_direction/reverse_direction.svg
@@ -15,7 +15,7 @@
      id="layer1">
     <path
        style="fill:none;stroke:#00aa00;stroke-width:18.4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 25,85 V 35 C 25.100727,6.7404564 75.224095,7.2276899 75,35 v 35"
+       d="M 25,85 V 35 C 25.100727,6.7404564 75.224095,7.2276899 75,35 v 38"
        id="path876" />
     <path
        style="fill:#00aa00;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,8 +200,11 @@ endforeach()
 # Copy executable
 install(TARGETS ${MR_TIMETABLE_PLANNER_TARGET})
 
-# Copy SVG icon
+# Copy SVG icons
 install(FILES ${CMAKE_SOURCE_DIR}/files/icons/lightning/lightning.svg
+    DESTINATION ${CMAKE_INSTALL_BINDIR}/icons)
+
+install(FILES ${CMAKE_SOURCE_DIR}/files/icons/reverse_direction/reverse_direction.svg
     DESTINATION ${CMAKE_INSTALL_BINDIR}/icons)
 
 # For each .ts file install corrensponding .qm file

--- a/src/jobs/jobeditor/editstopdialog.cpp
+++ b/src/jobs/jobeditor/editstopdialog.cpp
@@ -411,7 +411,6 @@ int EditStopDialog::getTrainSpeedKmH(bool afterStop)
 
 void EditStopDialog::updateAdditionalNotes()
 {
-    const StopItem& prevStop = helper->getPrevItem();
     const StopItem& curStop = helper->getCurItem();
 
     QString msg;
@@ -422,7 +421,7 @@ void EditStopDialog::updateAdditionalNotes()
     {
         //Ignore First and Last stop (sometimes they have fake in/out gates set which might trigger this message)
         //Both entry and exit path are set, check direction
-        if(curStop.fromGate.stationTrackSide == curStop.toGate.stationTrackSide && prevStop.stopId)
+        if(curStop.fromGate.stationTrackSide == curStop.toGate.stationTrackSide)
         {
             //Train leaves station track from same side of entrance
             msg = tr("Train reverses direction.");

--- a/src/jobs/jobeditor/editstopdialog.cpp
+++ b/src/jobs/jobeditor/editstopdialog.cpp
@@ -41,6 +41,8 @@ EditStopDialog::EditStopDialog(StopModel *m, QWidget *parent) :
     helper = new StopEditingHelper(Session->m_Db, stopModel,
                                    ui->outGateTrackSpin, ui->arrivalTimeEdit, ui->departureTimeEdit,
                                    this);
+    connect(helper, &StopEditingHelper::nextSegmentChosen, this, &EditStopDialog::updateAdditionalNotes);
+    connect(helper, &StopEditingHelper::stationTrackChosen, this, &EditStopDialog::updateAdditionalNotes);
 
     CustomCompletionLineEdit *mStationEdit = helper->getStationEdit();
     CustomCompletionLineEdit *mStTrackEdit = helper->getStTrackEdit();
@@ -242,6 +244,8 @@ void EditStopDialog::updateInfo()
     }
 
     couplingMgr->loadCouplings(stopModel, curStop.stopId, m_jobId, curStop.arrival);
+
+    updateAdditionalNotes();
 }
 
 void EditStopDialog::saveDataToModel()
@@ -403,6 +407,60 @@ int EditStopDialog::getTrainSpeedKmH(bool afterStop)
 
     q.step();
     return q.getRows().get<int>(0);
+}
+
+void EditStopDialog::updateAdditionalNotes()
+{
+    const StopItem& prevStop = helper->getPrevItem();
+    const StopItem& curStop = helper->getCurItem();
+
+    QString msg;
+
+    //Check direction
+    if(curStop.fromGate.gateConnId && curStop.toGate.gateConnId
+        && curStop.type != StopType::First && curStop.type != StopType::Last)
+    {
+        //Ignore First and Last stop (sometimes they have fake in/out gates set which might trigger this message)
+        //Both entry and exit path are set, check direction
+        if(curStop.fromGate.stationTrackSide == curStop.toGate.stationTrackSide && prevStop.stopId)
+        {
+            //Train leaves station track from same side of entrance
+            msg = tr("Train reverses direction.");
+        }
+    }
+
+    //Check line traction
+    if(curStop.type != StopType::Last && curStop.nextSegment.segmentId)
+    {
+        //Last has no next segment so do not show traction type
+
+        bool nextSegmentElectrified = stopModel->isRailwayElectrifiedAfterRow(stopIdx.row());
+        bool prevSegmentElectrified = !nextSegmentElectrified; //Trigger change on First stop
+
+        if(curStop.type != StopType::First && stopIdx.row() >= 0)
+        {
+            //Get real previous railway type
+            prevSegmentElectrified = stopModel->isRailwayElectrifiedAfterRow(stopIdx.row() - 1);
+        }
+
+        if(!msg.isEmpty())
+            msg.append("\n\n"); //Separate from previous message
+
+        if(nextSegmentElectrified)
+            msg.append(tr("Electric traction is ALLOWED."));
+        else
+            msg.append(tr("Electric traction is NOT ALLOWED."));
+
+        if(nextSegmentElectrified != prevSegmentElectrified && curStop.type != StopType::First)
+        {
+            //Railway type changed
+            msg.append('\n');
+            msg.append(tr("(Different traction then previous line!)"));
+        }
+    }
+
+    ui->additionalNotesLabel->setText(msg);
+    ui->additionalNotesBox->setVisible(!msg.isEmpty());
 }
 
 void EditStopDialog::setReadOnly(bool value)

--- a/src/jobs/jobeditor/editstopdialog.h
+++ b/src/jobs/jobeditor/editstopdialog.h
@@ -49,6 +49,8 @@ private slots:
 
     void couplingCustomContextMenuRequested(const QPoint &pos);
 
+    void updateAdditionalNotes();
+
 private:
     void saveDataToModel();
 

--- a/src/jobs/jobeditor/editstopdialog.ui
+++ b/src/jobs/jobeditor/editstopdialog.ui
@@ -220,6 +220,25 @@
          </layout>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QGroupBox" name="additionalNotesBox">
+         <property name="title">
+          <string>Additional Notes</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QLabel" name="additionalNotesLabel">
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="rsTab">

--- a/src/jobs/jobeditor/model/stopmodel.h
+++ b/src/jobs/jobeditor/model/stopmodel.h
@@ -7,7 +7,7 @@
 #include <QVector>
 #include <QSet>
 
-#include "utils/types.h"
+#include "stations/station_utils.h"
 
 namespace sqlite3pp {
 class database;
@@ -20,6 +20,7 @@ struct StopItem
         db_id gateConnId = 0;
         db_id gateId = 0;
         int trackNum = -1;
+        utils::Side stationTrackSide = utils::Side::NSides;
     };
 
     struct Segment

--- a/src/jobs/jobeditor/model/stopmodel.h
+++ b/src/jobs/jobeditor/model/stopmodel.h
@@ -19,7 +19,7 @@ struct StopItem
     {
         db_id gateConnId = 0;
         db_id gateId = 0;
-        int trackNum = -1;
+        int gateTrackNum = -1;
         utils::Side stationTrackSide = utils::Side::NSides;
     };
 

--- a/src/jobs/jobeditor/stopdelegate.cpp
+++ b/src/jobs/jobeditor/stopdelegate.cpp
@@ -68,7 +68,7 @@ void StopDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
 
     const double arrX = left + width * (isTransit ? 0.4 : 0.2);
     const double depX = left + width * 0.6;
-    const double lineX = left + (isTransit ? width * 0.1 : 0.0);
+    const double transitLineX = left + width * 0.1;
 
 
     if(item.addHere == 0)
@@ -109,8 +109,8 @@ void StopDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
             if(nextSegmentElectrified != prevSegmentElectrified)
             {
                 //Railway type changed, draw a lightning
-                QSizeF s = QSizeF(renderer->defaultSize()).scaled(width, height / 2, Qt::KeepAspectRatio);
-                QRectF lightningRect(left, top + height / 4, s.width(), s.height());
+                QSizeF s = QSizeF(renderer->defaultSize()).scaled(width, height * 0.4, Qt::KeepAspectRatio);
+                QRectF lightningRect(left, top + height * 0.1, s.width(), s.height());
                 renderer->render(painter, lightningRect);
 
                 if(!nextSegmentElectrified)
@@ -131,7 +131,7 @@ void StopDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
             q.reset();
 
             const double lineRightX = left + width * 0.8;
-            painter->drawText(QRectF(lineX, lineHeight, lineRightX - left, bottom - lineHeight),
+            painter->drawText(QRectF(transitLineX, lineHeight, lineRightX - left, bottom - lineHeight),
                               tr("Seg: %1").arg(segName),
                               QTextOption(Qt::AlignHCenter));
 
@@ -146,13 +146,13 @@ void StopDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
 
         if(isTransit)
         {
-            const double transitLinePos = rect.left() + rect.width() * 0.1;
-            painter->setPen(QPen(Qt::red, 5));
+            //Draw a vertical -0- to tell this is a transit
+            painter->setPen(QPen(Qt::red, 4));
             painter->setBrush(Qt::red);
-            painter->drawLine(QLineF(transitLinePos, rect.top(),
-                                     transitLinePos, rect.bottom()));
+            painter->drawLine(QLineF(transitLineX, rect.top(),
+                                     transitLineX, rect.bottom()));
 
-            painter->drawEllipse(QRectF(transitLinePos - 12 / 2,
+            painter->drawEllipse(QRectF(transitLineX - 12 / 2,
                                         rect.top() + rect.height() * 0.4,
                                         12, 12));
         }
@@ -174,16 +174,16 @@ QSize StopDelegate::sizeHint(const QStyleOptionViewItem &/*option*/,
                              const QModelIndex &index) const
 {
     int w = 200;
-    int h = 100;
+    int h = NormalStopHeight;
     const StopModel *model = static_cast<const StopModel *>(index.model());
     if(index.row() < 0 || index.row() >= model->rowCount())
-        return QSize(w, 30);
+        return QSize(w, AddHereHeight);
 
     const StopItem& item = model->getItemAt(index.row());
     if(item.type == StopType::Transit)
-        h = 80;
+        h = TransitStopHeight;
     if(item.addHere != 0)
-        h = 30;
+        h = AddHereHeight;
     return QSize(w, h);
 }
 

--- a/src/jobs/jobeditor/stopdelegate.cpp
+++ b/src/jobs/jobeditor/stopdelegate.cpp
@@ -135,11 +135,11 @@ void StopDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
                               tr("Seg: %1").arg(segName),
                               QTextOption(Qt::AlignHCenter));
 
-            if(item.toGate.trackNum != 0)
+            if(item.toGate.gateTrackNum != 0)
             {
                 painter->setPen(QPen(Qt::red, 4));
                 painter->drawText(QRectF(lineRightX, lineHeight, left + width - lineRightX, bottom - lineHeight),
-                                  QString::number(item.toGate.trackNum),
+                                  QString::number(item.toGate.gateTrackNum),
                                   QTextOption(Qt::AlignHCenter));
             }
         }

--- a/src/jobs/jobeditor/stopdelegate.h
+++ b/src/jobs/jobeditor/stopdelegate.h
@@ -68,6 +68,10 @@ private slots:
 private:
     QSvgRenderer *renderer;
     sqlite3pp::database &mDb;
+
+    static constexpr int NormalStopHeight = 100;
+    static constexpr int TransitStopHeight = 80;
+    static constexpr int AddHereHeight = 30;
 };
 
 #endif // STOPDELEGATE_H

--- a/src/jobs/jobeditor/stopdelegate.h
+++ b/src/jobs/jobeditor/stopdelegate.h
@@ -3,10 +3,6 @@
 
 #include <QStyledItemDelegate>
 
-#include "utils/types.h"
-
-#include <QSvgRenderer>
-
 namespace sqlite3pp {
 class database;
 }
@@ -41,8 +37,6 @@ public:
 
     void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &) const override;
 
-    void loadIcon(const QString& fileName);
-
 signals:
     /*!
      * \brief popupEditorSegmentCombo
@@ -66,12 +60,20 @@ private slots:
     void onEditorSegmentChosen(StopEditor *editor);
 
 private:
-    QSvgRenderer *renderer;
+    void refreshPixmaps();
+
+private:
     sqlite3pp::database &mDb;
+
+    QPixmap m_lightningPix;
+    QPixmap m_reverseDirPix;
 
     static constexpr int NormalStopHeight = 100;
     static constexpr int TransitStopHeight = 80;
     static constexpr int AddHereHeight = 30;
+
+    static constexpr int PixWidth = 35;
+    static constexpr int PixHeight = PixWidth;
 };
 
 #endif // STOPDELEGATE_H

--- a/src/jobs/jobeditor/stopeditinghelper.cpp
+++ b/src/jobs/jobeditor/stopeditinghelper.cpp
@@ -265,7 +265,7 @@ void StopEditingHelper::checkOutGateTrack()
         return; //First we need to have a segment
 
     int trackNum = mOutGateTrackSpin->value();
-    curStop.toGate.trackNum = trackNum; //Trigger checking of railway segment connections
+    curStop.toGate.gateTrackNum = trackNum; //Trigger checking of railway segment connections
 
     db_id segOutGateId = 0;
     if(model->trySelectNextSegment(curStop, curStop.nextSegment.segmentId, trackNum, 0, segOutGateId))
@@ -273,7 +273,7 @@ void StopEditingHelper::checkOutGateTrack()
         //Update gate track
         updateGateTrackSpin(curStop.toGate);
 
-        if(curStop.toGate.trackNum != trackNum)
+        if(curStop.toGate.gateTrackNum != trackNum)
         {
             //It wasn't possible to set requested track
             QMessageBox::warning(mEditor, tr("Stop Error"),
@@ -283,7 +283,7 @@ void StopEditingHelper::checkOutGateTrack()
                                     " on available tracks.")
                                      .arg(trackNum)
                                      .arg(mOutGateEdit->text())
-                                     .arg(curStop.toGate.trackNum));
+                                     .arg(curStop.toGate.gateTrackNum));
         }
 
         //Success, close editor
@@ -356,6 +356,6 @@ void StopEditingHelper::updateGateTrackSpin(const StopItem::Gate &toGate)
     //Prevent trigger valueChanged() signal
     mOutGateTrackSpin->blockSignals(true);
     mOutGateTrackSpin->setMaximum(qMax(0, outTrackCount - 1)); //At least one track numbered 0
-    mOutGateTrackSpin->setValue(toGate.trackNum);
+    mOutGateTrackSpin->setValue(toGate.gateTrackNum);
     mOutGateTrackSpin->blockSignals(false);
 }

--- a/src/jobs/jobeditor/stopeditinghelper.cpp
+++ b/src/jobs/jobeditor/stopeditinghelper.cpp
@@ -209,6 +209,8 @@ void StopEditingHelper::onStationSelected()
     mOutGateEdit->setData(0); //Reset, user must choose again
 
     curStop.nextSegment = StopItem::Segment{};
+
+    emit stationTrackChosen();
 }
 
 void StopEditingHelper::onTrackSelected()
@@ -229,6 +231,8 @@ void StopEditingHelper::onTrackSelected()
         if(!stillSucceded)
             mStTrackEdit->setData(curStop.trackId); //Reset to previous track
     }
+
+    emit stationTrackChosen();
 }
 
 void StopEditingHelper::onOutGateSelected(const QModelIndex &idx)

--- a/src/jobs/jobeditor/stopeditinghelper.h
+++ b/src/jobs/jobeditor/stopeditinghelper.h
@@ -47,6 +47,7 @@ protected:
 
 signals:
     void nextSegmentChosen();
+    void stationTrackChosen();
 
 private slots:
     void onStationSelected();

--- a/src/odt_export/common/odtutils.h
+++ b/src/odt_export/common/odtutils.h
@@ -132,6 +132,9 @@ public:
     static constexpr Text jobStopPassingsShort = QT_TRANSLATE_NOOP3("Odt", "Passes", "Job stop passings abbreviated column");
     static constexpr Text notes = QT_TRANSLATE_NOOP3("Odt", "Notes", "Job stop table");
 
+    //Job stops
+    static constexpr Text jobReverseDirection = QT_TRANSLATE_NOOP3("Odt", "Reverse direction", "Job stop table");
+
     //Shift
     static constexpr Text shiftCoverTitle = QT_TRANSLATE_NOOP3("Odt", "SHIFT %1", "Shift title in shift sheet cover");
     static constexpr Text shiftDocTitle   = QT_TRANSLATE_NOOP3("Odt", "Shift %1", "Shift sheet document title for metadata");

--- a/src/stations/manager/stationplanmodel.h
+++ b/src/stations/manager/stationplanmodel.h
@@ -17,8 +17,6 @@ struct StPlanItem
     QTime departure;
     QString platform;
 
-    QString description;
-
     JobCategory cat;
 
     enum class ItemType : qint8
@@ -28,6 +26,8 @@ struct StPlanItem
         Transit
     };
     ItemType type;
+
+    bool reversesDirection;
 };
 
 class StationPlanModel : public QAbstractTableModel

--- a/src/translations/mrtp_de.ts
+++ b/src/translations/mrtp_de.ts
@@ -404,18 +404,18 @@ All segments after it are also removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="233"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="252"/>
         <source>Coupled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="257"/>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="291"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="276"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="310"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="267"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="286"/>
         <source>Uncoupled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -425,22 +425,22 @@ All segments after it are also removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="371"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="390"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="227"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="246"/>
         <source>Rollingstock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="360"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="379"/>
         <source>Asset After Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="314"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="333"/>
         <source>Asset Before Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -458,6 +458,7 @@ All segments after it are also removed.</source>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="142"/>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="156"/>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="213"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="232"/>
         <source>TextLabel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -469,7 +470,7 @@ All segments after it are also removed.</source>
     </message>
     <message>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="172"/>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="217"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="219"/>
         <source>Current Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -494,77 +495,102 @@ All segments after it are also removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="301"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="226"/>
+        <source>Additional Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="320"/>
         <source>Job Asset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="421"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="440"/>
         <source>Passings / Crossings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="427"/>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="365"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="446"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="369"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="434"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="453"/>
         <source>Passings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="444"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="463"/>
         <source>Crossings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="211"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="213"/>
         <source>First Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="217"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="219"/>
         <source>Last Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="271"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="275"/>
         <source>Couple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="289"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="293"/>
         <source>Uncouple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="444"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="427"/>
+        <source>Train reverses direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="449"/>
+        <source>Electric traction is ALLOWED.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="451"/>
+        <source>Electric traction is NOT ALLOWED.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="457"/>
+        <source>(Different traction then previous line!)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="501"/>
         <source>No Engine Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="446"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="503"/>
         <source>It seems you have uncoupled all job engines except for electric ones but the line is not electrified
 (The train isn&apos;t able to move)
 Do you want to couple a non electric engine?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="450"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="507"/>
         <source>It seems you have uncoupled all job engines
 (The train isn&apos;t able to move)
 Do you want to couple an engine?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="483"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="540"/>
         <source>Train Speed Changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="484"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="541"/>
         <source>Train speed after this stop has changed from a value of %1 km/h to &lt;b&gt;%2 km/h&lt;/b&gt;&lt;br&gt;Do you want to rebase travel times to this new speed?&lt;br&gt;NOTE: this doesn&apos;t affect stop times but you will lose manual adjustments to travel times</source>
         <translation type="unfinished"></translation>
     </message>
@@ -633,7 +659,7 @@ Do you want to couple an engine?</source>
 <context>
     <name>FilterHeaderView</name>
     <message>
-        <location filename="../utils/delegates/sql/filterheaderview.cpp" line="172"/>
+        <location filename="../utils/delegates/sql/filterheaderview.cpp" line="171"/>
         <source>Type &lt;b&gt;#NULL&lt;/b&gt; to filter empty cells.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -934,93 +960,108 @@ Do you want to couple an engine?</source>
 <context>
     <name>JobPathEditor</name>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="58"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="20"/>
+        <source>Number:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="44"/>
+        <source>Category:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="69"/>
         <source>Save Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="223"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="230"/>
         <source>Toggle transit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="224"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="231"/>
         <source>Set transit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="225"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="232"/>
         <source>Unset transit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="230"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="237"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="234"/>
         <source>Edit stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="366"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="373"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="367"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="374"/>
         <source>You must register at least 2 stops.
 Do you want to delete this job?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="482"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="489"/>
         <source>Save?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="483"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="490"/>
         <source>Do you want to save changes to job %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="170"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="177"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="171"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="67"/>
+        <source>Shift:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="178"/>
         <source>Job number &lt;b&gt;%1&lt;/b&gt; is already exists.&lt;br&gt;Please choose a different number.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="228"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="235"/>
         <source>Station SVG Plan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="575"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="582"/>
         <source>Empty Job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="576"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="583"/>
         <source>Before setting a shift you should add stops to this job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="623"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="630"/>
         <source>Save Job Sheet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="627"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="634"/>
         <source>job%1_sheet.odt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="647"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="654"/>
         <source>Job Sheet Saved</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2271,12 +2312,18 @@ Extension: (*.ods)</source>
     </message>
     <message>
         <location filename="../odt_export/common/odtutils.h" line="136"/>
+        <source>Reverse direction</source>
+        <comment>Job stop table</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="139"/>
         <source>SHIFT %1</source>
         <comment>Shift title in shift sheet cover</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../odt_export/common/odtutils.h" line="137"/>
+        <location filename="../odt_export/common/odtutils.h" line="140"/>
         <source>Shift %1</source>
         <comment>Shift sheet document title for metadata</comment>
         <translation type="unfinished"></translation>
@@ -5154,33 +5201,39 @@ It can also be both (Bidirectional) but cannot be neither.</source>
 <context>
     <name>StationPlanModel</name>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="37"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="39"/>
         <source>Arrival</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="39"/>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="92"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="41"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="94"/>
         <source>Departure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="41"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="43"/>
         <source>Platform</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="43"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="45"/>
         <source>Job</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="45"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="47"/>
         <source>Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="108"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="97"/>
+        <source>Reverse direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="99"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="114"/>
         <source>Transit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5781,7 +5834,7 @@ Can be used instead of track length but is less precise.</source>
 <context>
     <name>StopDelegate</name>
     <message>
-        <location filename="../jobs/jobeditor/stopdelegate.cpp" line="135"/>
+        <location filename="../jobs/jobeditor/stopdelegate.cpp" line="148"/>
         <source>Seg: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5819,34 +5872,34 @@ Can be used instead of track length but is less precise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="229"/>
         <source>Gate Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="229"/>
         <source>Track Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="255"/>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="279"/>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="295"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="259"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="283"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="299"/>
         <source>Stop Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="255"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="259"/>
         <source>Cannot set segment &lt;b&gt;%1&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="280"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="284"/>
         <source>Requested gate out track &lt;b&gt;%1&lt;/b&gt; is not connected to segment &lt;b&gt;%2&lt;/b&gt;.&lt;br&gt;Out track &lt;b&gt;%3&lt;/b&gt; was chosen instead.&lt;br&gt;Look segment track connection from Stations Manager for more information on available tracks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="295"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="299"/>
         <source>Cannot set segment track!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5854,28 +5907,28 @@ Can be used instead of track length but is less precise.</source>
 <context>
     <name>StopModel</name>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1265"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1271"/>
         <source>Track belongs to a different station.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1270"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1276"/>
         <source>Track doesn&apos;t exist.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1282"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1288"/>
         <source>Track is not connected to any of station gates.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1308"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1316"/>
         <source>Track is not connected to in gate track.
 Please choose a new track or change previous segment.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1332"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1343"/>
         <source>Track is not connected to selected out gate track.
 Please choose a new out gate or out track, this might change next segment.</source>
         <translation type="unfinished"></translation>

--- a/src/translations/mrtp_it.ts
+++ b/src/translations/mrtp_it.ts
@@ -418,6 +418,7 @@ Tutte le tratte successive saranno inoltre rimosse.</translation>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="142"/>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="156"/>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="213"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="232"/>
         <source>TextLabel</source>
         <translation></translation>
     </message>
@@ -429,7 +430,7 @@ Tutte le tratte successive saranno inoltre rimosse.</translation>
     </message>
     <message>
         <location filename="../jobs/jobeditor/editstopdialog.ui" line="172"/>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="217"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="219"/>
         <source>Current Stop</source>
         <translation>Fermata Corrente</translation>
     </message>
@@ -454,18 +455,23 @@ Tutte le tratte successive saranno inoltre rimosse.</translation>
         <translation>Gate Entrata:</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="233"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="226"/>
+        <source>Additional Notes</source>
+        <translation>Note Aggiuntive</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="252"/>
         <source>Coupled</source>
         <translation>Agganciati</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="257"/>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="291"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="276"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="310"/>
         <source>Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="267"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="286"/>
         <source>Uncoupled</source>
         <translation>Sganciati</translation>
     </message>
@@ -475,78 +481,98 @@ Tutte le tratte successive saranno inoltre rimosse.</translation>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="371"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="390"/>
         <source>Info</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="227"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="246"/>
         <source>Rollingstock</source>
         <translation>Rotabili</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="301"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="320"/>
         <source>Job Asset</source>
         <translation>Assetto Treno</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="314"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="333"/>
         <source>Asset Before Stop</source>
         <translation>Assetto prima della fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="421"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="440"/>
         <source>Passings / Crossings</source>
         <translation>Precedenze / Incroci</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="434"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="453"/>
         <source>Passings</source>
         <translation>Precedenze</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="444"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="463"/>
         <source>Crossings</source>
         <translation>Incroci</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="360"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="379"/>
         <source>Asset After Stop</source>
         <translation>Assetto dopo la fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.ui" line="427"/>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="365"/>
+        <location filename="../jobs/jobeditor/editstopdialog.ui" line="446"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="369"/>
         <source>Refresh</source>
         <translation>Ricarica</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="211"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="213"/>
         <source>First Stop</source>
         <translation>Prima Fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="217"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="219"/>
         <source>Last Stop</source>
         <translation>Ultima Fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="271"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="275"/>
         <source>Couple</source>
         <translation>Aggancia</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="289"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="293"/>
         <source>Uncouple</source>
         <translation>Sgancia</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="444"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="427"/>
+        <source>Train reverses direction.</source>
+        <translation>Il Treno inverte la direzione.</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="449"/>
+        <source>Electric traction is ALLOWED.</source>
+        <translation>Trazione elettrica ABILITATA.</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="451"/>
+        <source>Electric traction is NOT ALLOWED.</source>
+        <translation>Trazione elettrica NON ABILITATA.</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="457"/>
+        <source>(Different traction then previous line!)</source>
+        <translation>(Differente trazione dalla precedente linea!)</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="501"/>
         <source>No Engine Left</source>
         <translation>Nessuna Locomotiva Rimasta</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="446"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="503"/>
         <source>It seems you have uncoupled all job engines except for electric ones but the line is not electrified
 (The train isn&apos;t able to move)
 Do you want to couple a non electric engine?</source>
@@ -555,7 +581,7 @@ Do you want to couple a non electric engine?</source>
 Vuoi agganciare una locomotiva non elettrica?</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="450"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="507"/>
         <source>It seems you have uncoupled all job engines
 (The train isn&apos;t able to move)
 Do you want to couple an engine?</source>
@@ -564,12 +590,12 @@ Do you want to couple an engine?</source>
 Vuoi lasciarne una agganciata?</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="483"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="540"/>
         <source>Train Speed Changed</source>
         <translation>La velocità del treno è cambiata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="484"/>
+        <location filename="../jobs/jobeditor/editstopdialog.cpp" line="541"/>
         <source>Train speed after this stop has changed from a value of %1 km/h to &lt;b&gt;%2 km/h&lt;/b&gt;&lt;br&gt;Do you want to rebase travel times to this new speed?&lt;br&gt;NOTE: this doesn&apos;t affect stop times but you will lose manual adjustments to travel times</source>
         <translation>La velocità del treno dopo questa fermata è cambiata da un valore di %1 km/h a &lt;b&gt;%2 km/h&lt;/b&gt;&lt;br&gt;Vuoi ricalcolare i tempi di percorrenza con questa nuova velocità?&lt;br&gt;NOTA: i tempi di sosta non sono affetti da questa modifica ma perderai gli aggiustamenti manuali fatti ai tempi di percorrenza</translation>
     </message>
@@ -638,7 +664,7 @@ Vuoi lasciarne una agganciata?</translation>
 <context>
     <name>FilterHeaderView</name>
     <message>
-        <location filename="../utils/delegates/sql/filterheaderview.cpp" line="172"/>
+        <location filename="../utils/delegates/sql/filterheaderview.cpp" line="171"/>
         <source>Type &lt;b&gt;#NULL&lt;/b&gt; to filter empty cells.</source>
         <translation>Inserisci &lt;b&gt;#NULL&lt;/b&gt; per filtrare le celle vuote.</translation>
     </message>
@@ -939,94 +965,109 @@ Vuoi lasciarne una agganciata?</translation>
 <context>
     <name>JobPathEditor</name>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="58"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="20"/>
+        <source>Number:</source>
+        <translation>Numero:</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="44"/>
+        <source>Category:</source>
+        <translation>Categoria:</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.ui" line="69"/>
         <source>Save Sheet</source>
         <translation>Salva Foglio</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="223"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="230"/>
         <source>Toggle transit</source>
         <translation>Commuta transito</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="230"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="237"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="234"/>
         <source>Edit stop</source>
         <translation>Modifica fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="224"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="67"/>
+        <source>Shift:</source>
+        <translation>Turno:</translation>
+    </message>
+    <message>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="231"/>
         <source>Set transit</source>
         <translation>Imposta transito</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="225"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="232"/>
         <source>Unset transit</source>
         <translation>Togli transito</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="228"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="235"/>
         <source>Station SVG Plan</source>
         <translation>Piano SVG Stazione</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="366"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="373"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="367"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="374"/>
         <source>You must register at least 2 stops.
 Do you want to delete this job?</source>
         <translation>Devi registrare almeno 2 fermate.
 Vuoi eliminare questo servizio?</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="482"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="489"/>
         <source>Save?</source>
         <translation>Salvare?</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="483"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="490"/>
         <source>Do you want to save changes to job %1</source>
         <translation>Vuoi salvare le modifiche fatte al servizio %1</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="647"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="654"/>
         <source>Job Sheet Saved</source>
         <translation>Foglio Servizio Salvato</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="170"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="177"/>
         <source>Invalid</source>
         <translation>Non valido</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="171"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="178"/>
         <source>Job number &lt;b&gt;%1&lt;/b&gt; is already exists.&lt;br&gt;Please choose a different number.</source>
         <translation>Il servizio numero &lt;b&gt;%1&lt;/b&gt; è già esistente.&lt;br&gt;Per favore scegli un numero diverso.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="575"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="582"/>
         <source>Empty Job</source>
         <translation>Servizio vuoto</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="576"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="583"/>
         <source>Before setting a shift you should add stops to this job</source>
         <translation>Prima di selezionare un turno dovresti aggiungere le fermate</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="623"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="630"/>
         <source>Save Job Sheet</source>
         <translation>Salva Foglio Servizio</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="627"/>
+        <location filename="../jobs/jobeditor/jobpatheditor.cpp" line="634"/>
         <source>job%1_sheet.odt</source>
         <translation>foglio_treno%1.odt</translation>
     </message>
@@ -2289,12 +2330,18 @@ Estensione: (*.ods)</translation>
     </message>
     <message>
         <location filename="../odt_export/common/odtutils.h" line="136"/>
+        <source>Reverse direction</source>
+        <comment>Job stop table</comment>
+        <translation>Inversione di marcia</translation>
+    </message>
+    <message>
+        <location filename="../odt_export/common/odtutils.h" line="139"/>
         <source>SHIFT %1</source>
         <comment>Shift title in shift sheet cover</comment>
         <translation>TURNO %1</translation>
     </message>
     <message>
-        <location filename="../odt_export/common/odtutils.h" line="137"/>
+        <location filename="../odt_export/common/odtutils.h" line="140"/>
         <source>Shift %1</source>
         <comment>Shift sheet document title for metadata</comment>
         <translation>Turno %1</translation>
@@ -5205,33 +5252,39 @@ Può anche essere entrambi (Bidirezionale) ma non può non essere nessuno dei du
 <context>
     <name>StationPlanModel</name>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="37"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="39"/>
         <source>Arrival</source>
         <translation>Arrivo</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="39"/>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="92"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="41"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="94"/>
         <source>Departure</source>
         <translation>Partenza</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="41"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="43"/>
         <source>Platform</source>
         <translation>Binario</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="43"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="45"/>
         <source>Job</source>
         <translation>Servizio</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="45"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="47"/>
         <source>Notes</source>
         <translation>Note</translation>
     </message>
     <message>
-        <location filename="../stations/manager/stationplanmodel.cpp" line="108"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="97"/>
+        <source>Reverse direction</source>
+        <translation>Inversione di marcia</translation>
+    </message>
+    <message>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="99"/>
+        <location filename="../stations/manager/stationplanmodel.cpp" line="114"/>
         <source>Transit</source>
         <translation>Transito</translation>
     </message>
@@ -5839,7 +5892,7 @@ Può essere utilizzata al posto della lunghezza del binario ma è meno precisa.<
 <context>
     <name>StopDelegate</name>
     <message>
-        <location filename="../jobs/jobeditor/stopdelegate.cpp" line="135"/>
+        <location filename="../jobs/jobeditor/stopdelegate.cpp" line="148"/>
         <source>Seg: %1</source>
         <translation>Tratta: %1</translation>
     </message>
@@ -5877,34 +5930,34 @@ Può essere utilizzata al posto della lunghezza del binario ma è meno precisa.<
         <translation>Non impostato!</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="229"/>
         <source>Gate Warning</source>
         <translation>Attenzione Gate</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="227"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="229"/>
         <source>Track Error</source>
         <translation>Errore Binario</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="255"/>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="279"/>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="295"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="259"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="283"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="299"/>
         <source>Stop Error</source>
         <translation>Errore Fermata</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="255"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="259"/>
         <source>Cannot set segment &lt;b&gt;%1&lt;/b&gt;</source>
         <translation>Impossibile impostare tratta &lt;b&gt;%1&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="280"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="284"/>
         <source>Requested gate out track &lt;b&gt;%1&lt;/b&gt; is not connected to segment &lt;b&gt;%2&lt;/b&gt;.&lt;br&gt;Out track &lt;b&gt;%3&lt;/b&gt; was chosen instead.&lt;br&gt;Look segment track connection from Stations Manager for more information on available tracks.</source>
         <translation>Il binario &lt;b&gt;%1&lt;/b&gt; di uscita del gate richiest non è connesso alla tratta &lt;b&gt;%2&lt;/b&gt;.&lt;br&gt;Il binario di uscita &lt;b&gt;%3&lt;/b&gt; è stato scelto al suo posto.&lt;br&gt;Vedi le connessioni dei binari della tratta attraverso il Manager Stazioni per maggiori informazioni sui binari disponibili.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="295"/>
+        <location filename="../jobs/jobeditor/stopeditinghelper.cpp" line="299"/>
         <source>Cannot set segment track!</source>
         <translation>Impossibile impostare il binario della tratta!</translation>
     </message>
@@ -5912,29 +5965,29 @@ Può essere utilizzata al posto della lunghezza del binario ma è meno precisa.<
 <context>
     <name>StopModel</name>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1265"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1271"/>
         <source>Track belongs to a different station.</source>
         <translation>Il Binario appartiene ad una stazione diversa.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1270"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1276"/>
         <source>Track doesn&apos;t exist.</source>
         <translation>Binario non esistente.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1282"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1288"/>
         <source>Track is not connected to any of station gates.</source>
         <translation>Il binario non è connesso a nessuno dei Gate della stazione.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1308"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1316"/>
         <source>Track is not connected to in gate track.
 Please choose a new track or change previous segment.</source>
         <translation>Il Binario non è connesso al Gate di Entrata.
 Per favore scegli un altro Binario o cambia la Tratta precedente.</translation>
     </message>
     <message>
-        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1332"/>
+        <location filename="../jobs/jobeditor/model/stopmodel.cpp" line="1343"/>
         <source>Track is not connected to selected out gate track.
 Please choose a new out gate or out track, this might change next segment.</source>
         <translation>Il Binario non è connesso al Gate di Uscita.


### PR DESCRIPTION
Detect train direction change on stops by comparing station track sides.
When a direction change is detected:

- draw a little U-shaped arrow near station in `JobPathEditor`
- In `EditStopDialog` tell user about it in "Additional Notes" section
- In Job (and Shift) and Station sheets prepend "Reverses direction" on stop description

In addition, show line traction type in `EditStopDialog`
Cache rendered SVG in pixmaps for `StopDelegate`