### PR TITLE
Delay LineGraphScene reload

### DIFF
--- a/src/app/session.h
+++ b/src/app/session.h
@@ -82,8 +82,8 @@ signals:
 
     //Stations
     void stationNameChanged(db_id stationId);
-    //TODO: separate job stop changes (time plan) from track changes (track plan)
-    void stationPlanChanged(const QSet<db_id>& stationIds);
+    void stationJobsPlanChanged(const QSet<db_id>& stationIds);
+    void stationTrackPlanChanged(const QSet<db_id>& stationIds);
     void stationRemoved(db_id stationId);
 
     //Segments

--- a/src/graph/model/linegraphmanager.h
+++ b/src/graph/model/linegraphmanager.h
@@ -27,6 +27,13 @@ public:
     explicit LineGraphManager(QObject *parent = nullptr);
 
     /*!
+     * \brief react to line graph update events
+     *
+     * \sa processPendingUpdates()
+     */
+    bool event(QEvent *ev) override;
+
+    /*!
      * \brief subscribe scene to notifications
      *
      * The scene gets registered on this manager and will be refreshed
@@ -66,6 +73,27 @@ public:
      * \sa LineGraphScene::getSelectedJob()
      */
     JobStopEntry getCurrentSelectedJob() const;
+
+    /*!
+     * \brief schedule async update
+     *
+     * If an update is already schedule, does nothing.
+     * Otherwise posts an event to self so it will update
+     * when Qt event loop is not busy
+     *
+     * \sa processPendingUpdates()
+     */
+    void scheduleUpdate();
+
+    /*!
+     * \brief process pending updates
+     *
+     * Updates all scenes marked for update
+     *
+     * \sa scheduleUpdate()
+     * \sa event()
+     */
+    void processPendingUpdates();
 
 signals:
     /*!
@@ -135,6 +163,7 @@ private:
     LineGraphScene *activeScene;
     JobStopEntry lastSelectedJob;
     bool m_followJobOnGraphChange;
+    bool m_hasScheduledUpdate;
 };
 
 #endif // LINEGRAPHMANAGER_H

--- a/src/graph/model/linegraphmanager.h
+++ b/src/graph/model/linegraphmanager.h
@@ -139,7 +139,7 @@ private slots:
 
     //Stations
     void onStationNameChanged(db_id stationId);
-    void onStationPlanChanged(const QSet<db_id> &stationIds);
+    void onStationJobPlanChanged(const QSet<db_id> &stationIds);
     void onStationRemoved(db_id stationId);
 
     //Segments

--- a/src/graph/model/linegraphmanager.h
+++ b/src/graph/model/linegraphmanager.h
@@ -140,6 +140,7 @@ private slots:
     //Stations
     void onStationNameChanged(db_id stationId);
     void onStationJobPlanChanged(const QSet<db_id> &stationIds);
+    void onStationTrackPlanChanged(const QSet<db_id> &stationIds);
     void onStationRemoved(db_id stationId);
 
     //Segments
@@ -157,6 +158,9 @@ private slots:
 
     //Settings
     void updateGraphOptions();
+
+private:
+    void onStationPlanChanged_internal(const QSet<db_id> &stationIds, int flag);
 
 private:
     QVector<LineGraphScene *> scenes;

--- a/src/graph/model/linegraphscene.cpp
+++ b/src/graph/model/linegraphscene.cpp
@@ -201,6 +201,9 @@ bool LineGraphScene::loadGraph(db_id objectId, LineGraphType type, bool force)
 
     reloadJobs();
 
+    //Reset pending update
+    pendingUpdate = PendingUpdate::NothingToDo;
+
     emit graphChanged(int(graphType), graphObjectId, this);
     emit redrawGraph();
 

--- a/src/graph/model/linegraphscene.h
+++ b/src/graph/model/linegraphscene.h
@@ -31,6 +31,20 @@ class LineGraphScene : public IGraphScene
 {
     Q_OBJECT
 public:
+    /*!
+     * \brief Enum to describe pending update needed
+     *
+     * FIXME: allow to specify segments to update
+     */
+    enum class PendingUpdate
+    {
+        NothingToDo = 0x0, //!< No content needs updating
+        ReloadJobs = 0x1, //!< Only Jobs need to be reloaded
+        ReloadStationNames = 0x2, //!< Only Station Names but not Station Plan has changed
+        FullReload = 0x4 //!< Do a full reload
+    };
+    Q_DECLARE_FLAGS(PendingUpdateFlags, PendingUpdate)
+
     LineGraphScene(sqlite3pp::database &db, QObject *parent = nullptr);
 
     void renderContents(QPainter *painter, const QRectF& sceneRect) override;
@@ -317,6 +331,8 @@ private:
     JobStopEntry selectedJob;
 
     bool m_drawSelection;
+
+    PendingUpdateFlags pendingUpdate;
 };
 
 #endif // LINEGRAPHSCENE_H

--- a/src/graph/model/linegraphscene.h
+++ b/src/graph/model/linegraphscene.h
@@ -260,6 +260,14 @@ private:
     bool loadStation(StationGraphObject &st, QString &outFullName);
 
     /*!
+     * \brief updateStationNames
+     *
+     * Update names of already loaded stations
+     * If graph type is SingleStation, graph name will be update too
+     */
+    bool updateStationNames();
+
+    /*!
      * \brief Load all stations in a railway line
      *
      * Loads stations of all railway line segments

--- a/src/jobs/jobeditor/jobpatheditor.cpp
+++ b/src/jobs/jobeditor/jobpatheditor.cpp
@@ -436,7 +436,7 @@ bool JobPathEditor::saveChanges()
     emit Session->rollingStockPlanChanged(rsToUpdate);
 
     //Update station views
-    emit Session->stationPlanChanged(stationsToUpdate);
+    emit Session->stationJobsPlanChanged(stationsToUpdate);
 
     //When updating the path selection gets cleared so we restore it
     Session->getViewManager()->requestJobSelection(stopModel->getJobId(), true, true);
@@ -488,7 +488,7 @@ void JobPathEditor::discardChanges()
     emit Session->rollingStockPlanChanged(rsToUpdate);
 
     //Update station views
-    emit Session->stationPlanChanged(stationsToUpdate);
+    emit Session->stationJobsPlanChanged(stationsToUpdate);
 }
 
 db_id JobPathEditor::currentJobId() const

--- a/src/jobs/jobeditor/jobpatheditor.cpp
+++ b/src/jobs/jobeditor/jobpatheditor.cpp
@@ -425,18 +425,7 @@ bool JobPathEditor::saveChanges()
         }
     }
 
-    //Store before they are cleared on commitChanges()
-    const auto stationsToUpdate = stopModel->getStationsToUpdate();
-    const auto rsToUpdate = stopModel->getRsToUpdate();
-
-    //FIXME: does not update line scene correctly
     stopModel->commitChanges();
-
-    //Update views
-    emit Session->rollingStockPlanChanged(rsToUpdate);
-
-    //Update station views
-    emit Session->stationJobsPlanChanged(stationsToUpdate);
 
     //When updating the path selection gets cleared so we restore it
     Session->getViewManager()->requestJobSelection(stopModel->getJobId(), true, true);
@@ -458,10 +447,6 @@ void JobPathEditor::discardChanges()
 
     stopJobNumberTimer();
 
-    //Save them before reverting changes
-    QSet<db_id> rsToUpdate = stopModel->getRsToUpdate();
-    QSet<db_id> stationsToUpdate = stopModel->getStationsToUpdate();
-
     stopModel->revertChanges(); //Re-load old job from db
 
     //After re-load but before possible 'clearJob()' (Below)
@@ -481,14 +466,6 @@ void JobPathEditor::discardChanges()
         clearJob();
         setEnabled(false);
     }
-
-    //After possible job deletion update views
-
-    //Update RS views
-    emit Session->rollingStockPlanChanged(rsToUpdate);
-
-    //Update station views
-    emit Session->stationJobsPlanChanged(stationsToUpdate);
 }
 
 db_id JobPathEditor::currentJobId() const

--- a/src/jobs/jobsmanager/model/jobshelper.cpp
+++ b/src/jobs/jobsmanager/model/jobshelper.cpp
@@ -113,7 +113,7 @@ bool JobsHelper::removeJob(sqlite3pp::database &db, db_id jobId)
     emit Session->jobRemoved(jobId);
 
     //Refresh graphs and station views
-    emit Session->stationPlanChanged(stationsToUpdate);
+    emit Session->stationJobsPlanChanged(stationsToUpdate);
 
     //Refresh Rollingstock views
     emit Session->rollingStockPlanChanged(rsToUpdate);
@@ -285,7 +285,7 @@ bool JobsHelper::copyStops(sqlite3pp::database &db, db_id fromJobId, db_id toJob
     }
 
     //Refresh graphs and station views
-    emit Session->stationPlanChanged(stationsToUpdate);
+    emit Session->stationJobsPlanChanged(stationsToUpdate);
 
     //Refresh Rollingstock views
     emit Session->rollingStockPlanChanged(rsToUpdate);

--- a/src/stations/manager/segments/model/railwaysegmentsplithelper.cpp
+++ b/src/stations/manager/segments/model/railwaysegmentsplithelper.cpp
@@ -85,7 +85,8 @@ bool RailwaySegmentSplitHelper::split()
     stationsToUpdate.insert(newSegInfo.to.stationId);
 
     emit Session->segmentStationsChanged(origSegInfo.segmentId);
-    emit Session->stationPlanChanged(stationsToUpdate);
+    emit Session->stationTrackPlanChanged(stationsToUpdate);
+    emit Session->stationJobsPlanChanged(stationsToUpdate);
 
     return true;
 }

--- a/src/stations/manager/stationsmanager.cpp
+++ b/src/stations/manager/stationsmanager.cpp
@@ -387,7 +387,8 @@ void StationsManager::onEditStation()
 
     //FIXME: check if actually changed
     emit Session->stationNameChanged(stId);
-    emit Session->stationPlanChanged({stId});
+    emit Session->stationTrackPlanChanged({stId});
+    emit Session->stationJobsPlanChanged({stId});
 
     //Refresh segments
     int &segmentsTimer = clearModelTimers[RailwaySegmentsTab];

--- a/src/utils/worker_event_types.h
+++ b/src/utils/worker_event_types.h
@@ -45,7 +45,10 @@ enum class CustomEvents
     JobsModelResult,
 
     //Printing
-    PrintProgress
+    PrintProgress,
+
+    //Line Graph Manager
+    LineGraphManagerUpdate
 };
 
 #endif // WORKER_EVENT_TYPES_H

--- a/src/viewmanager/viewmanager.cpp
+++ b/src/viewmanager/viewmanager.cpp
@@ -50,7 +50,7 @@ ViewManager::ViewManager(QObject *parent) :
     //Stations
     connect(Session, &MeetingSession::stationRemoved, this, &ViewManager::onStRemoved);
     connect(Session, &MeetingSession::stationNameChanged, this, &ViewManager::onStNameChanged);
-    connect(Session, &MeetingSession::stationPlanChanged, this, &ViewManager::onStPlanChanged);
+    connect(Session, &MeetingSession::stationJobsPlanChanged, this, &ViewManager::onStPlanChanged);
 
     //Shifts
     connect(Session, &MeetingSession::shiftNameChanged, this, &ViewManager::onShiftEdited);


### PR DESCRIPTION
When we will have multiple line views, updating should be done in event loop to avoid freezing the UI.

- Do batch updates, cumulate all changes to every scene and then update only once (saves time)
- Fix scene not correctly updated in some cases (e.g. changing Job ID without other modifications didn't trigger update)
- LineGraphScene: light update when only station names change but not the rest.