### PR TITLE
Feature: Import SVG station connections

### DIFF
--- a/src/stations/manager/stations/dialogs/stationeditdialog.h
+++ b/src/stations/manager/stations/dialogs/stationeditdialog.h
@@ -68,6 +68,7 @@ private slots:
     void addSVGImage();
     void removeSVGImage();
     void saveSVGToFile();
+    void importConnFromSVG();
 
     //Xml Plan
     void saveXmlPlan();

--- a/src/stations/manager/stations/dialogs/stationeditdialog.ui
+++ b/src/stations/manager/stations/dialogs/stationeditdialog.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>622</width>
-    <height>385</height>
+    <height>425</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -116,17 +116,10 @@
           <string>SVG Image</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QPushButton" name="addSVGBut">
+          <item row="1" column="1">
+           <widget class="QPushButton" name="saveXMLBut">
             <property name="text">
-             <string>Add Image</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QPushButton" name="remSVGBut">
-            <property name="text">
-             <string>Remove Image</string>
+             <string>Save XML to file</string>
             </property>
            </widget>
           </item>
@@ -137,10 +130,24 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="saveXMLBut">
+          <item row="0" column="1">
+           <widget class="QPushButton" name="remSVGBut">
             <property name="text">
-             <string>Save XML to file</string>
+             <string>Remove Image</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QPushButton" name="addSVGBut">
+            <property name="text">
+             <string>Add Image</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QPushButton" name="importConnBut">
+            <property name="text">
+             <string>Import Connections</string>
             </property>
            </widget>
           </item>

--- a/src/stations/manager/stations/model/stationsvghelper.h
+++ b/src/stations/manager/stations/model/stationsvghelper.h
@@ -74,6 +74,9 @@ public:
     static bool writeStationXml(QIODevice *dev, ssplib::StationPlan *plan);
 
     static bool writeStationXmlFromDB(sqlite3pp::database &db, db_id stationId, QIODevice *dev);
+
+    static bool importTrackConnFromSVG(sqlite3pp::database &db, db_id stationId, ssplib::StationPlan *plan);
+    static bool importTrackConnFromSVGDev(sqlite3pp::database &db, db_id stationId, QIODevice *dev);
 };
 
 #endif // STATIONSVGHELPER_H


### PR DESCRIPTION
Automatically import **station track connections** from mapped station SVG image.
This is very useful if used with new version of [SVGStationPlanEditor](https://github.com/gfgit/SVGStationPlanEditor) (still experimental, see `layout_editor` branch)
It will automatically discover track connection in SVG and map them for you. Then with the generated image you import the connections in **ModelRailroadTimetablePlanner** with a single click!

