### PR TITLE
Fix broken src/graph/CMakeLists.txt file

### DIFF
--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -1,4 +1,8 @@
-add_subdirectory(model) add_subdirectory(view)
+add_subdirectory(model)
+add_subdirectory(view)
 
-  set(MR_TIMETABLE_PLANNER_SOURCES ${MR_TIMETABLE_PLANNER_SOURCES} graph / linegraphtypes.h graph
-      / linegraphtypes.cpp PARENT_SCOPE)
+set(MR_TIMETABLE_PLANNER_SOURCES
+    ${MR_TIMETABLE_PLANNER_SOURCES}
+    graph/linegraphtypes.h
+    graph/linegraphtypes.cpp
+    PARENT_SCOPE)


### PR DESCRIPTION
Revert changes to `src/graph/CMakeLists.txt` file, which somehow got modified in 9f14ee1c64b3b9d399078918fc20ccce7bc4a7d9 